### PR TITLE
Add tests for invoices and recurring revenues

### DIFF
--- a/tests/Feature/InvoiceTest.php
+++ b/tests/Feature/InvoiceTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Invoice;
+use App\Models\InvoiceItem;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InvoiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_cannot_access_invoices()
+    {
+        $response = $this->get('/invoices');
+        $response->assertRedirect('/login');
+    }
+
+    public function test_authenticated_user_can_create_invoice_with_items()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post('/invoices', [
+            'client_name' => 'Client',
+            'client_email' => 'client@example.com',
+            'client_address' => 'Address',
+            'number' => 'INV-001',
+            'issue_date' => now()->toDateString(),
+            'due_date' => now()->addWeek()->toDateString(),
+            'items' => [
+                [
+                    'description' => 'Service',
+                    'quantity' => 1,
+                    'price' => 1000,
+                ],
+            ],
+        ]);
+
+        $response->assertRedirect('/invoices');
+        $this->assertDatabaseHas('invoices', [
+            'number' => 'INV-001',
+            'client_name' => 'Client',
+            'total' => 1000,
+        ]);
+        $this->assertDatabaseHas('invoice_items', [
+            'description' => 'Service',
+            'quantity' => 1,
+            'price' => 1000,
+        ]);
+    }
+
+    public function test_user_can_send_and_mark_invoice_paid()
+    {
+        $user = User::factory()->create();
+        $invoice = Invoice::create([
+            'number' => 'INV-100',
+            'issue_date' => now()->toDateString(),
+            'due_date' => now()->addWeek()->toDateString(),
+            'status' => 'Draft',
+            'total' => 500,
+            'client_name' => 'Client',
+            'client_email' => 'client@example.com',
+            'client_address' => 'Address',
+        ]);
+
+        InvoiceItem::create([
+            'invoice_id' => $invoice->id,
+            'description' => 'Item',
+            'quantity' => 1,
+            'price' => 500,
+        ]);
+
+        $this->actingAs($user)->post(route('invoices.send', $invoice));
+        $this->assertDatabaseHas('invoices', [
+            'id' => $invoice->id,
+            'status' => 'Sent',
+        ]);
+
+        $this->actingAs($user)->post(route('invoices.pay', $invoice));
+        $this->assertDatabaseHas('invoices', [
+            'id' => $invoice->id,
+            'status' => 'Paid',
+        ]);
+    }
+}

--- a/tests/Feature/RecurringRevenueTest.php
+++ b/tests/Feature/RecurringRevenueTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Category;
+use App\Models\RecurringRevenue;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RecurringRevenueTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_cannot_access_recurring_revenues()
+    {
+        $response = $this->get('/recurring_revenues');
+        $response->assertRedirect('/login');
+    }
+
+    public function test_authenticated_user_can_create_recurring_revenue()
+    {
+        $user = User::factory()->create();
+        $category = Category::factory()->create();
+
+        $response = $this->actingAs($user)->post('/recurring_revenues', [
+            'category_id' => $category->id,
+            'user_id' => $user->id,
+            'amount' => 1000,
+            'frequency' => 'monthly',
+            'next_run' => now()->addMonth()->toDateString(),
+            'description' => 'Langganan',
+        ]);
+
+        $response->assertRedirect('/recurring_revenues');
+        $this->assertDatabaseHas('recurring_revenues', [
+            'category_id' => $category->id,
+            'user_id' => $user->id,
+            'amount' => 1000,
+            'frequency' => 'monthly',
+            'description' => 'Langganan',
+        ]);
+    }
+
+    public function test_user_can_pause_and_resume_recurring_revenue()
+    {
+        $user = User::factory()->create();
+        $category = Category::factory()->create();
+        $revenue = RecurringRevenue::create([
+            'category_id' => $category->id,
+            'user_id' => $user->id,
+            'amount' => 2000,
+            'frequency' => 'monthly',
+            'next_run' => now()->addMonth()->toDateString(),
+            'paused' => false,
+        ]);
+
+        $this->actingAs($user)->patch(route('recurring_revenues.pause', $revenue));
+        $this->assertDatabaseHas('recurring_revenues', [
+            'id' => $revenue->id,
+            'paused' => true,
+        ]);
+
+        $this->actingAs($user)->patch(route('recurring_revenues.resume', $revenue));
+        $this->assertDatabaseHas('recurring_revenues', [
+            'id' => $revenue->id,
+            'paused' => false,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add feature tests for recurring revenue CRUD and pause/resume
- add invoice feature tests including item creation and status updates

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/vodeco-keuangan/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_b_68b7f69b4f98832685acf61ef0aea51e