### PR TITLE
Disable CSRF verification in tests

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,8 +2,16 @@
 
 namespace Tests;
 
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware(VerifyCsrfToken::class);
+    }
 }


### PR DESCRIPTION
## Summary
- Disable CSRF middleware during tests by importing VerifyCsrfToken and overriding setUp in base TestCase

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_b_68b9140a6210832faf9d146576cd483a