### PR TITLE
Adjust primary blue palette to navy

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,20 @@ export default {
             fontFamily: {
                 sans: ['Figtree', ...defaultTheme.fontFamily.sans],
             },
+            colors: {
+                blue: {
+                    50: '#f2f4ff',
+                    100: '#d9dff2',
+                    200: '#b3c0e6',
+                    300: '#8da0d9',
+                    400: '#4d64b3',
+                    500: '#1f3a99',
+                    600: '#000080',
+                    700: '#000066',
+                    800: '#00004d',
+                    900: '#000033',
+                },
+            },
         },
     },
 


### PR DESCRIPTION
## Summary
- override the Tailwind blue palette with navy-inspired shades centered on #000080
- ensure buttons and other blue accents use the updated navy tones across the app

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d3a0be0624832a95ecd1a91babc18e