### PR TITLE
style: redesign login screen

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,45 +1,45 @@
 <x-guest-layout>
     <!-- Session Status -->
-    <x-auth-session-status class="mb-4" :status="session('status')" />
+    <x-auth-session-status class="mb-4 text-sm font-medium text-emerald-200" :status="session('status')" />
 
     <form method="POST" action="{{ route('login') }}">
         @csrf
 
         <!-- Email Address -->
-        <div>
-            <x-input-label for="email" :value="__('Email')" />
-            <x-text-input id="email" class="block mt-1 w-full text-gray-600" type="email" name="email" :value="old('email')" required autofocus autocomplete="username" />
-            <x-input-error :messages="$errors->get('email')" class="mt-2" />
+        <div class="space-y-2">
+            <x-input-label for="email" :value="__('Nama Pengguna atau Alamat Email')" class="text-sm font-semibold text-indigo-100" />
+            <x-text-input id="email" class="block mt-1 w-full border-transparent bg-white/90 text-gray-900 placeholder-indigo-200 focus:border-indigo-400 focus:ring-indigo-300" type="email" name="email" :value="old('email')" required autofocus autocomplete="username" />
+            <x-input-error :messages="$errors->get('email')" class="mt-2 text-sm text-rose-200" />
         </div>
 
         <!-- Password -->
-        <div class="mt-4">
-            <x-input-label for="password" :value="__('Password')" />
+        <div class="mt-6 space-y-2">
+            <x-input-label for="password" :value="__('Password')" class="text-sm font-semibold text-indigo-100" />
 
-            <x-text-input id="password" class="block mt-1 w-full text-gray-600"
+            <x-text-input id="password" class="block mt-1 w-full border-transparent bg-white/90 text-gray-900 placeholder-indigo-200 focus:border-indigo-400 focus:ring-indigo-300"
                             type="password"
                             name="password"
                             required autocomplete="current-password" />
 
-            <x-input-error :messages="$errors->get('password')" class="mt-2" />
+            <x-input-error :messages="$errors->get('password')" class="mt-2 text-sm text-rose-200" />
         </div>
 
         <!-- Remember Me -->
         <div class="block mt-4">
             <label for="remember_me" class="inline-flex items-center">
-                <input id="remember_me" type="checkbox" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500" name="remember">
-                <span class="ms-2 text-sm text-gray-600">{{ __('Remember me') }}</span>
+                <input id="remember_me" type="checkbox" class="rounded border-transparent bg-white/20 text-indigo-200 shadow-sm focus:ring-indigo-300" name="remember">
+                <span class="ms-2 text-sm text-indigo-100">{{ __('Remember me') }}</span>
             </label>
         </div>
 
-        <div class="flex items-center justify-end mt-4">
+        <div class="mt-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             @if (Route::has('password.request'))
-                <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" href="{{ route('password.request') }}">
+                <a class="text-sm font-medium text-indigo-100 underline decoration-indigo-300/50 underline-offset-4 transition hover:text-white" href="{{ route('password.request') }}">
                     {{ __('Forgot your password?') }}
                 </a>
             @endif
 
-            <x-primary-button class="mx-3 bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
+            <x-primary-button class="inline-flex justify-center rounded-full bg-gradient-to-r from-indigo-400 to-violet-500 px-6 py-3 text-sm font-semibold uppercase tracking-widest text-white shadow-lg shadow-indigo-900/40 transition hover:from-indigo-300 hover:to-violet-400 focus:outline-none focus:ring-2 focus:ring-indigo-200 focus:ring-offset-2 focus:ring-offset-indigo-900">
                 {{ __('Log in') }}
             </x-primary-button>
         </div>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -15,17 +15,57 @@
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])
     </head>
-    <body class="font-sans text-gray-900 dark:text-white antialiased">
-        <div class="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-gray-100">
-            <div>
-                <a href="/">
-                    <x-application-logo class="h-12 fill-current text-gray-500" />
-                </a>
-            </div>
+    <body class="font-sans antialiased bg-gray-900">
+        <div class="min-h-screen flex flex-col lg:flex-row">
+            <aside class="hidden lg:flex lg:w-1/2 bg-white text-gray-900">
+                <div class="flex flex-col justify-between w-full px-12 py-10">
+                    <div class="flex items-center justify-start">
+                        <a href="/" class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition hover:border-indigo-500 hover:text-indigo-600">
+                            <span class="inline-flex h-2 w-2 rounded-full bg-indigo-500"></span>
+                            <span>Kembali ke Vodeco</span>
+                        </a>
+                    </div>
 
-            <div class="w-full sm:max-w-md mt-6 px-6 py-4 bg-white shadow-md overflow-hidden sm:rounded-lg">
-                {{ $slot }}
-            </div>
+                    <div class="mt-12 flex-1">
+                        <div class="max-w-lg">
+                            <p class="text-sm font-semibold uppercase tracking-[0.35em] text-indigo-500">3+ Team</p>
+                            <p class="mt-4 text-5xl font-bold text-gray-900">Memberdayakan Bisnis Anda dengan Inovasi Digital</p>
+                            <p class="mt-6 text-base text-gray-600">Lebih dari 5 tahun pengalaman membantu lebih dari 23 orang profesional mewujudkan solusi digital terbaik.</p>
+                        </div>
+
+                        <div class="mt-10">
+                            <img src="{{ asset('login-page-vodeco.png') }}" alt="Tim Vodeco" class="w-full max-w-xl rounded-3xl shadow-xl ring-1 ring-indigo-100">
+                        </div>
+                    </div>
+
+                    <div class="mt-12 text-sm text-gray-500">
+                        <p>© {{ now()->year }} Vodeco. All rights reserved.</p>
+                    </div>
+                </div>
+            </aside>
+
+            <main class="flex-1 bg-gradient-to-b from-[#1B1741] via-[#261F6E] to-[#3A1E94] text-white">
+                <div class="flex min-h-screen flex-col justify-center px-6 py-12 sm:px-12">
+                    <div class="mx-auto w-full max-w-md space-y-10">
+                        <div class="flex flex-col items-center space-y-4 text-center">
+                            <img src="{{ asset('logo-vodeco-dark-mode.png') }}" alt="Logo Vodeco" class="h-14">
+                            <div>
+                                <p class="text-lg font-semibold tracking-wide text-indigo-100">Let’s Lift Your Brand</p>
+                                <h1 class="mt-2 text-3xl font-bold">Masuk ke Dashboard Vodeco</h1>
+                                <p class="mt-2 text-sm text-indigo-100">Silakan masuk menggunakan email dan kata sandi yang terdaftar.</p>
+                            </div>
+                        </div>
+
+                        <div class="rounded-3xl bg-white/10 p-8 shadow-xl shadow-indigo-900/20 backdrop-blur-lg">
+                            {{ $slot }}
+                        </div>
+
+                        <div class="text-center text-sm text-indigo-100/80">
+                            <p>Dengan masuk, Anda menyetujui <a href="#" class="font-medium text-white underline decoration-indigo-200/60 underline-offset-4 hover:text-indigo-200">Kebijakan Privasi</a>.</p>
+                        </div>
+                    </div>
+                </div>
+            </main>
         </div>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle the guest layout to match the updated Vodeco login art direction with a split hero panel and gradient form background
- refresh the login form styling while keeping the existing fields intact

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_b_68d7527ebf0c8331b15ffae61782644e