### PR TITLE
Set default report range to full month

### DIFF
--- a/app/Http/Requests/ReportRequest.php
+++ b/app/Http/Requests/ReportRequest.php
@@ -107,7 +107,7 @@ class ReportRequest extends FormRequest
             case 'range':
             default:
                 $startDate = $startDate ?? Carbon::now()->startOfMonth()->toDateString();
-                $endDate = $endDate ?? Carbon::now()->toDateString();
+                $endDate = $endDate ?? Carbon::now()->endOfMonth()->toDateString();
                 break;
         }
 


### PR DESCRIPTION
## Summary
- default the custom report range to span the entire current month when no dates are provided

## Testing
- php artisan test *(fails: vendor/autoload.php missing in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d784a3d31883318c4f9011bd346c46