### PR TITLE
Remove CSV export option from reports

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -138,7 +138,7 @@ class ReportController extends Controller
         $validated = $request->validated();
         $startDate = $validated['start_date'];
         $endDate = $validated['end_date'];
-        $format = $validated['format'] ?? 'xlsx'; // xlsx atau csv
+        $format = $validated['format'] ?? 'xlsx';
         $currentUser = $request->user();
         $shouldFilterByUser = ! in_array($currentUser->role, [Role::ADMIN, Role::ACCOUNTANT]);
 

--- a/app/Http/Controllers/SettingController.php
+++ b/app/Http/Controllers/SettingController.php
@@ -130,7 +130,7 @@ class SettingController extends Controller
         $validated = $request->validate([
             'start_date' => 'required|date',
             'end_date' => 'required|date|after_or_equal:start_date',
-            'format' => 'required|in:xlsx,csv',
+            'format' => 'required|in:xlsx',
         ]);
 
         $startDate = $validated['start_date'];

--- a/app/Http/Requests/ReportRequest.php
+++ b/app/Http/Requests/ReportRequest.php
@@ -25,7 +25,7 @@ class ReportRequest extends FormRequest
         return [
             'start_date' => ['required', 'date', 'before_or_equal:end_date'],
             'end_date' => ['required', 'date'],
-            'format' => ['in:xlsx,csv'],
+            'format' => ['nullable', 'in:xlsx'],
             'category_id' => ['nullable', 'exists:categories,id'],
             'type' => ['nullable', 'in:pemasukan,pengeluaran'],
             'period' => ['nullable', 'in:range,daily,monthly,yearly'],
@@ -131,7 +131,7 @@ class ReportRequest extends FormRequest
             'start_date.before_or_equal' => 'Tanggal mulai tidak boleh lebih besar dari tanggal akhir.',
             'end_date.required' => 'Tanggal akhir wajib diisi.',
             'end_date.date' => 'Tanggal akhir tidak valid.',
-            'format.in' => 'Format harus salah satu dari: xlsx, csv.',
+            'format.in' => 'Format harus berupa file Excel (.xlsx).',
             'category_id.exists' => 'Kategori yang dipilih tidak ditemukan.',
             'type.in' => 'Tipe transaksi tidak valid.',
             'period.in' => 'Jenis rentang waktu tidak valid.',

--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -95,10 +95,8 @@
                 <div x-show="open" @click.away="open = false" class="absolute right-0 top-full z-10 mt-2 w-48 overflow-hidden rounded-xl border border-gray-100 bg-white text-sm shadow-lg">
                     @php
                         $exportXlsxParams = array_merge($exportQuery, ['format' => 'xlsx']);
-                        $exportCsvParams = array_merge($exportQuery, ['format' => 'csv']);
                     @endphp
                     <a href="{{ route('reports.export', $exportXlsxParams) }}" class="block px-4 py-2 text-gray-700 transition hover:bg-gray-50">Excel (.xlsx)</a>
-                    <a href="{{ route('reports.export', $exportCsvParams) }}" class="block px-4 py-2 text-gray-700 transition hover:bg-gray-50">CSV (.csv)</a>
                 </div>
             </div>
         </div>

--- a/resources/views/settings/data.blade.php
+++ b/resources/views/settings/data.blade.php
@@ -7,7 +7,7 @@
         {{-- Kartu Ekspor Data --}}
         <div class="bg-white rounded-lg shadow-sm p-8">
             <h3 class="text-xl font-semibold text-gray-900 dark:text-white mb-2">Ekspor Data Transaksi</h3>
-            <p class="text-gray-600 mb-6">Pilih rentang tanggal dan format file untuk mengekspor data transaksi Anda.</p>
+            <p class="text-gray-600 mb-6">Pilih rentang tanggal untuk mengekspor data transaksi Anda dalam format Excel.</p>
 
             <form method="POST" action="{{ route('settings.export') }}">
                 @csrf
@@ -30,7 +30,6 @@
                     <label for="format" class="block text-sm font-medium text-gray-700 mb-1">Format File</label>
                     <select name="format" id="format" class="w-full border rounded-lg text-sm px-4 py-2 focus:ring-blue-500 focus:border-blue-500">
                         <option value="xlsx">Excel (.xlsx)</option>
-                        <option value="csv">CSV (.csv)</option>
                     </select>
                 </div>
 


### PR DESCRIPTION
## Summary
- remove CSV export links so financial reports only offer Excel downloads
- update export validation to accept Excel format exclusively and clarify messaging

## Testing
- php artisan test *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_b_68d7890efc0083319beda4759d6ac203