### PR TITLE
Enhance financial reports export and layout

### DIFF
--- a/app/Exports/FinancialReportExport.php
+++ b/app/Exports/FinancialReportExport.php
@@ -2,23 +2,18 @@
 
 namespace App\Exports;
 
+use App\Services\FinancialReportService;
 use Illuminate\Contracts\View\View;
 use Maatwebsite\Excel\Concerns\FromView;
-use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Concerns\WithTitle;
-use Maatwebsite\Excel\Events\AfterSheet;
-use App\Models\Transaction;
-use App\Models\Debt;
 
-class FinancialReportExport implements FromView, WithTitle, WithEvents
+class FinancialReportExport implements FromView, WithTitle
 {
     protected ?int $userId;
     protected string $startDate;
     protected string $endDate;
     protected ?int $categoryId;
     protected ?string $type;
-    protected int $transactionCount = 0;
-    protected int $debtCount = 0;
 
     public function __construct(?int $userId, string $startDate, string $endDate, ?int $categoryId = null, ?string $type = null)
     {
@@ -31,41 +26,20 @@ class FinancialReportExport implements FromView, WithTitle, WithEvents
 
     public function view(): View
     {
-        $transactionQuery = Transaction::with('category')
-            ->when($this->userId !== null, function ($query) {
-                $query->where('user_id', $this->userId);
-            })
-            ->whereBetween('date', [$this->startDate, $this->endDate]);
-
-        if ($this->categoryId) {
-            $transactionQuery->where('category_id', $this->categoryId);
-        }
-
-        if ($this->type) {
-            $transactionQuery->whereHas('category', function ($query) {
-                $query->where('type', $this->type);
-            });
-        }
-
-        $transactions = $transactionQuery
-            ->orderBy('date', 'asc')
-            ->get();
-
-        $this->transactionCount = $transactions->count();
-
-        $debts = Debt::with('payments')
-            ->when($this->userId !== null, function ($query) {
-                $query->where('user_id', $this->userId);
-            })
-            ->whereBetween('due_date', [$this->startDate, $this->endDate])
-            ->orderBy('due_date', 'asc')
-            ->get();
-
-        $this->debtCount = $debts->count();
+        $reportData = app(FinancialReportService::class)->generate(
+            $this->userId,
+            $this->startDate,
+            $this->endDate,
+            $this->categoryId,
+            $this->type
+        );
 
         return view('exports.financial_report', [
-            'transactions' => $transactions,
-            'debts' => $debts
+            ...$reportData,
+            'period' => [
+                'start' => $this->startDate,
+                'end' => $this->endDate,
+            ],
         ]);
     }
 
@@ -74,68 +48,4 @@ class FinancialReportExport implements FromView, WithTitle, WithEvents
         return 'Laporan Keuangan';
     }
 
-    public function registerEvents(): array
-    {
-        return [
-            AfterSheet::class => function (AfterSheet $event) {
-                $sheet = $event->sheet->getDelegate();
-
-                $debtHeaderRow = null;
-                $highestRow = $sheet->getHighestRow();
-
-                for ($row = 1; $row <= $highestRow; $row++) {
-                    if ($sheet->getCell('A' . $row)->getValue() === 'Pihak Terkait') {
-                        $debtHeaderRow = $row;
-                        break;
-                    }
-                }
-
-                if ($debtHeaderRow === null) {
-                    return;
-                }
-
-                $sheet->insertNewRowBefore($debtHeaderRow, 1);
-                $transactionSummaryRow = $debtHeaderRow;
-                $debtHeaderRow += 1;
-
-                $transactionDataStartRow = 2;
-
-                $sheet->setCellValue('D' . $transactionSummaryRow, 'Total');
-
-                if ($this->transactionCount > 0) {
-                    $sheet->setCellValue(
-                        'E' . $transactionSummaryRow,
-                        sprintf('=SUM(E%d:E%d)', $transactionDataStartRow, $transactionDataStartRow + $this->transactionCount - 1)
-                    );
-                } else {
-                    $sheet->setCellValue('E' . $transactionSummaryRow, 0);
-                }
-
-                $debtDataStartRow = $debtHeaderRow + 1;
-                $debtSummaryRow = $debtDataStartRow + $this->debtCount;
-
-                $sheet->setCellValue('A' . $debtSummaryRow, 'Total');
-
-                if ($this->debtCount > 0) {
-                    $debtDataEndRow = $debtDataStartRow + $this->debtCount - 1;
-                    $sheet->setCellValue(
-                        'C' . $debtSummaryRow,
-                        sprintf('=SUM(C%d:C%d)', $debtDataStartRow, $debtDataEndRow)
-                    );
-                    $sheet->setCellValue(
-                        'D' . $debtSummaryRow,
-                        sprintf('=SUM(D%d:D%d)', $debtDataStartRow, $debtDataEndRow)
-                    );
-                    $sheet->setCellValue(
-                        'E' . $debtSummaryRow,
-                        sprintf('=SUM(E%d:E%d)', $debtDataStartRow, $debtDataEndRow)
-                    );
-                } else {
-                    $sheet->setCellValue('C' . $debtSummaryRow, 0);
-                    $sheet->setCellValue('D' . $debtSummaryRow, 0);
-                    $sheet->setCellValue('E' . $debtSummaryRow, 0);
-                }
-            }
-        ];
-    }
 }

--- a/app/Http/Requests/ReportRequest.php
+++ b/app/Http/Requests/ReportRequest.php
@@ -25,7 +25,7 @@ class ReportRequest extends FormRequest
         return [
             'start_date' => ['required', 'date', 'before_or_equal:end_date'],
             'end_date' => ['required', 'date'],
-            'format' => ['nullable', 'in:xlsx'],
+            'format' => ['nullable', 'in:xlsx,pdf'],
             'category_id' => ['nullable', 'exists:categories,id'],
             'type' => ['nullable', 'in:pemasukan,pengeluaran'],
             'period' => ['nullable', 'in:range,daily,monthly,yearly'],
@@ -131,7 +131,7 @@ class ReportRequest extends FormRequest
             'start_date.before_or_equal' => 'Tanggal mulai tidak boleh lebih besar dari tanggal akhir.',
             'end_date.required' => 'Tanggal akhir wajib diisi.',
             'end_date.date' => 'Tanggal akhir tidak valid.',
-            'format.in' => 'Format harus berupa file Excel (.xlsx).',
+            'format.in' => 'Format harus berupa file Excel (.xlsx) atau PDF (.pdf).',
             'category_id.exists' => 'Kategori yang dipilih tidak ditemukan.',
             'type.in' => 'Tipe transaksi tidak valid.',
             'period.in' => 'Jenis rentang waktu tidak valid.',

--- a/app/Services/FinancialReportService.php
+++ b/app/Services/FinancialReportService.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Debt;
+use App\Models\Transaction;
+
+class FinancialReportService
+{
+    /**
+     * Bangun data laporan keuangan yang sudah dipisahkan berdasarkan jenis transaksi.
+     */
+    public function generate(
+        ?int $userId,
+        string $startDate,
+        string $endDate,
+        ?int $categoryId = null,
+        ?string $type = null
+    ): array {
+        $transactionQuery = Transaction::with('category')
+            ->when($userId !== null, function ($query) use ($userId) {
+                $query->where('user_id', $userId);
+            })
+            ->whereBetween('date', [$startDate, $endDate]);
+
+        if ($categoryId) {
+            $transactionQuery->where('category_id', $categoryId);
+        }
+
+        if ($type) {
+            $transactionQuery->whereHas('category', function ($query) use ($type) {
+                $query->where('type', $type);
+            });
+        }
+
+        $transactions = $transactionQuery
+            ->orderBy('date')
+            ->orderBy('id')
+            ->get();
+
+        $incomeTransactions = $transactions
+            ->filter(fn ($transaction) => $transaction->category && $transaction->category->type === 'pemasukan')
+            ->values();
+
+        $expenseTransactions = $transactions
+            ->filter(fn ($transaction) => $transaction->category && $transaction->category->type === 'pengeluaran')
+            ->values();
+
+        $totalIncome = $incomeTransactions->sum('amount');
+        $totalExpense = $expenseTransactions->sum('amount');
+
+        $debts = Debt::with('payments')
+            ->when($userId !== null, function ($query) use ($userId) {
+                $query->where('user_id', $userId);
+            })
+            ->whereBetween('due_date', [$startDate, $endDate])
+            ->orderBy('due_date')
+            ->orderBy('id')
+            ->get();
+
+        $totalDebt = $debts->sum('amount');
+        $totalPaidDebt = $debts->sum('paid_amount');
+        $totalRemainingDebt = $debts->sum('remaining_amount');
+
+        return [
+            'transactions' => $transactions,
+            'incomeTransactions' => $incomeTransactions,
+            'expenseTransactions' => $expenseTransactions,
+            'debts' => $debts,
+            'totals' => [
+                'pemasukan' => $totalIncome,
+                'pengeluaran' => $totalExpense,
+                'selisih' => $totalIncome - $totalExpense,
+                'hutang' => $totalDebt,
+                'pembayaranHutang' => $totalPaidDebt,
+                'sisaHutang' => $totalRemainingDebt,
+            ],
+        ];
+    }
+}

--- a/resources/views/exports/financial_report_pdf.blade.php
+++ b/resources/views/exports/financial_report_pdf.blade.php
@@ -4,6 +4,15 @@
     <meta charset="UTF-8">
     <title>Laporan Keuangan</title>
     @include('exports.partials.financial_report_styles')
+    <style>
+        body {
+            padding: 32px 40px;
+        }
+
+        .report-wrapper {
+            width: 100%;
+        }
+    </style>
 </head>
 <body>
     <div class="report-wrapper">

--- a/resources/views/exports/partials/financial_report_styles.blade.php
+++ b/resources/views/exports/partials/financial_report_styles.blade.php
@@ -1,0 +1,162 @@
+<style>
+    :root {
+        color-scheme: light;
+    }
+
+    * {
+        box-sizing: border-box;
+    }
+
+    body {
+        font-family: 'Segoe UI', Arial, sans-serif;
+        color: #1f2937;
+        background-color: #f8fafc;
+        margin: 0;
+        padding: 24px;
+    }
+
+    .report-wrapper {
+        max-width: 1200px;
+        margin: 0 auto;
+    }
+
+    h1 {
+        margin-bottom: 4px;
+        font-size: 28px;
+        color: #000080;
+    }
+
+    .report-period {
+        margin: 0 0 24px 0;
+        color: #475569;
+        font-size: 14px;
+    }
+
+    .summary-grid {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        margin-bottom: 24px;
+    }
+
+    .summary-card {
+        flex: 1 1 220px;
+        background: linear-gradient(135deg, rgba(0, 0, 128, 0.08), rgba(0, 0, 128, 0.18));
+        border: 1px solid rgba(0, 0, 128, 0.25);
+        border-radius: 16px;
+        padding: 16px 20px;
+    }
+
+    .summary-label {
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 12px;
+        color: #1e3a8a;
+        margin-bottom: 6px;
+    }
+
+    .summary-value {
+        font-size: 20px;
+        font-weight: 700;
+        color: #000080;
+    }
+
+    .table-section {
+        margin-bottom: 32px;
+        background: #ffffff;
+        border-radius: 18px;
+        border: 1px solid rgba(0, 0, 128, 0.15);
+        padding: 20px 24px;
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+    }
+
+    .section-title {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        background-color: #000080;
+        color: #ffffff;
+        padding: 10px 18px;
+        border-radius: 999px;
+        font-size: 16px;
+        font-weight: 600;
+        letter-spacing: 0.03em;
+        text-transform: uppercase;
+    }
+
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 18px;
+        font-size: 13px;
+    }
+
+    thead th {
+        background-color: #000080;
+        color: #ffffff;
+        padding: 12px 14px;
+        text-align: left;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+    }
+
+    tbody td {
+        padding: 12px 14px;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.4);
+        color: #1f2937;
+        line-height: 1.5;
+        vertical-align: top;
+    }
+
+    tfoot td {
+        padding: 12px 14px;
+        font-weight: 700;
+        color: #000080;
+        background: rgba(0, 0, 128, 0.05);
+        border-top: 1px solid rgba(0, 0, 128, 0.15);
+    }
+
+    .text-right {
+        text-align: right;
+    }
+
+    .text-center {
+        text-align: center;
+    }
+
+    .status-badge {
+        display: inline-flex;
+        padding: 4px 12px;
+        border-radius: 999px;
+        font-size: 12px;
+        font-weight: 600;
+    }
+
+    .status-paid {
+        background-color: rgba(16, 185, 129, 0.15);
+        color: #047857;
+    }
+
+    .status-unpaid {
+        background-color: rgba(248, 113, 113, 0.15);
+        color: #b91c1c;
+    }
+
+    .empty-state {
+        padding: 20px;
+        text-align: center;
+        color: #64748b;
+        font-style: italic;
+    }
+
+    .dual-table {
+        display: grid;
+        gap: 24px;
+    }
+
+    @media (min-width: 900px) {
+        .dual-table {
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+    }
+</style>

--- a/resources/views/exports/partials/financial_report_tables.blade.php
+++ b/resources/views/exports/partials/financial_report_tables.blade.php
@@ -1,0 +1,147 @@
+@php
+    $formatCurrency = fn ($value) => 'Rp' . number_format($value, 0, ',', '.');
+@endphp
+
+<div class="summary-grid">
+    <div class="summary-card">
+        <div class="summary-label">Total Pemasukan</div>
+        <div class="summary-value">{{ $formatCurrency($totals['pemasukan'] ?? 0) }}</div>
+    </div>
+    <div class="summary-card">
+        <div class="summary-label">Total Pengeluaran</div>
+        <div class="summary-value">{{ $formatCurrency($totals['pengeluaran'] ?? 0) }}</div>
+    </div>
+    <div class="summary-card">
+        <div class="summary-label">Saldo Bersih</div>
+        <div class="summary-value">{{ $formatCurrency($totals['selisih'] ?? 0) }}</div>
+    </div>
+    <div class="summary-card">
+        <div class="summary-label">Total Hutang</div>
+        <div class="summary-value">{{ $formatCurrency($totals['hutang'] ?? 0) }}</div>
+    </div>
+    <div class="summary-card">
+        <div class="summary-label">Pembayaran Hutang</div>
+        <div class="summary-value">{{ $formatCurrency($totals['pembayaranHutang'] ?? 0) }}</div>
+    </div>
+    <div class="summary-card">
+        <div class="summary-label">Sisa Hutang</div>
+        <div class="summary-value">{{ $formatCurrency($totals['sisaHutang'] ?? 0) }}</div>
+    </div>
+</div>
+
+<div class="table-section">
+    <span class="section-title">Pemasukan &amp; Pengeluaran</span>
+    <div class="dual-table">
+        <div>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Tanggal</th>
+                        <th>Kategori</th>
+                        <th>Deskripsi</th>
+                        <th class="text-right">Jumlah</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($incomeTransactions as $transaction)
+                        <tr>
+                            <td>{{ \Carbon\Carbon::parse($transaction->date)->isoFormat('D MMMM YYYY') }}</td>
+                            <td>{{ $transaction->category?->name }}</td>
+                            <td>{{ $transaction->description }}</td>
+                            <td class="text-right">{{ $formatCurrency($transaction->amount) }}</td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="4" class="empty-state">Tidak ada pemasukan pada periode ini.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <td colspan="3">Total Pemasukan</td>
+                        <td class="text-right">{{ $formatCurrency($totals['pemasukan'] ?? 0) }}</td>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+        <div>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Tanggal</th>
+                        <th>Kategori</th>
+                        <th>Deskripsi</th>
+                        <th class="text-right">Jumlah</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($expenseTransactions as $transaction)
+                        <tr>
+                            <td>{{ \Carbon\Carbon::parse($transaction->date)->isoFormat('D MMMM YYYY') }}</td>
+                            <td>{{ $transaction->category?->name }}</td>
+                            <td>{{ $transaction->description }}</td>
+                            <td class="text-right">{{ $formatCurrency($transaction->amount) }}</td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="4" class="empty-state">Tidak ada pengeluaran pada periode ini.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <td colspan="3">Total Pengeluaran</td>
+                        <td class="text-right">{{ $formatCurrency($totals['pengeluaran'] ?? 0) }}</td>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+    </div>
+</div>
+
+<div class="table-section">
+    <span class="section-title">Laporan Hutang</span>
+    <table>
+        <thead>
+            <tr>
+                <th>Pihak Terkait</th>
+                <th>Deskripsi</th>
+                <th class="text-right">Jumlah</th>
+                <th class="text-right">Terbayar</th>
+                <th class="text-right">Sisa</th>
+                <th>Jatuh Tempo</th>
+                <th>Status</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse($debts as $debt)
+                <tr>
+                    <td>{{ $debt->related_party }}</td>
+                    <td>{{ $debt->description }}</td>
+                    <td class="text-right">{{ $formatCurrency($debt->amount) }}</td>
+                    <td class="text-right">{{ $formatCurrency($debt->paid_amount) }}</td>
+                    <td class="text-right">{{ $formatCurrency($debt->remaining_amount) }}</td>
+                    <td>{{ \Carbon\Carbon::parse($debt->due_date)->isoFormat('D MMMM YYYY') }}</td>
+                    <td>
+                        <span class="status-badge {{ $debt->status === 'lunas' ? 'status-paid' : 'status-unpaid' }}">
+                            {{ ucfirst($debt->status) }}
+                        </span>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="7" class="empty-state">Tidak ada data hutang pada periode ini.</td>
+                </tr>
+            @endforelse
+        </tbody>
+        <tfoot>
+            <tr>
+                <td colspan="2">Total</td>
+                <td class="text-right">{{ $formatCurrency($totals['hutang'] ?? 0) }}</td>
+                <td class="text-right">{{ $formatCurrency($totals['pembayaranHutang'] ?? 0) }}</td>
+                <td class="text-right">{{ $formatCurrency($totals['sisaHutang'] ?? 0) }}</td>
+                <td colspan="2"></td>
+            </tr>
+        </tfoot>
+    </table>
+</div>

--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -92,11 +92,13 @@
                     </svg>
                     <span>Unduh Laporan</span>
                 </button>
-                <div x-show="open" @click.away="open = false" class="absolute right-0 top-full z-10 mt-2 w-48 overflow-hidden rounded-xl border border-gray-100 bg-white text-sm shadow-lg">
+                <div x-show="open" @click.away="open = false" class="absolute right-0 top-full z-10 mt-2 w-56 overflow-hidden rounded-xl border border-gray-100 bg-white text-sm shadow-lg">
                     @php
                         $exportXlsxParams = array_merge($exportQuery, ['format' => 'xlsx']);
+                        $exportPdfParams = array_merge($exportQuery, ['format' => 'pdf']);
                     @endphp
                     <a href="{{ route('reports.export', $exportXlsxParams) }}" class="block px-4 py-2 text-gray-700 transition hover:bg-gray-50">Excel (.xlsx)</a>
+                    <a href="{{ route('reports.export', $exportPdfParams) }}" class="block border-t border-gray-100 px-4 py-2 text-gray-700 transition hover:bg-gray-50">PDF Landscape (.pdf)</a>
                 </div>
             </div>
         </div>
@@ -161,77 +163,186 @@
 </div>
 
 
-{{-- Tabel Rincian Transaksi --}}
-<div class="bg-white rounded-lg shadow-sm p-6 mb-8">
-    <h3 class="text-xl font-semibold text-gray-900  mb-4">Rincian Transaksi</h3>
-    <div class="overflow-x-auto">
-        <table class="w-full text-left">
-            <thead class="border-b">
-                <tr>
-                    <th class="px-6 py-3 text-xs font-semibold tracking-wider text-gray-500 uppercase">Tanggal</th>
-                    <th class="px-6 py-3 text-xs font-semibold tracking-wider text-gray-500 uppercase">Kategori</th>
-                    <th class="px-6 py-3 text-xs font-semibold tracking-wider text-gray-500 uppercase">Deskripsi</th>
-                    <th class="px-6 py-3 text-xs font-semibold tracking-wider text-gray-500 uppercase text-right">Jumlah</th>
-                </tr>
-            </thead>
-            <tbody class="divide-y">
-                @forelse($transactions as $transaction)
-                <tr>
-                    <td class="px-6 py-4 text-sm font-medium text-gray-900  whitespace-nowrap">{{ \Carbon\Carbon::parse($transaction->date)->isoFormat('D MMM YYYY') }}</td>
-                    <td class="px-6 py-4 text-sm text-gray-500 whitespace-nowrap">{{ $transaction->category->name }}</td>
-                    <td class="px-6 py-4 text-sm text-gray-500 whitespace-nowrap">{{ $transaction->description }}</td>
-                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-right {{ $transaction->category->type == 'pemasukan' ? 'text-green-600' : 'text-red-600' }}">
-                        {{ $transaction->category->type == 'pemasukan' ? '+' : '-' }} Rp{{ number_format($transaction->amount, 0, ',', '.') }}
-                    </td>
-                </tr>
-                @empty
-                <tr>
-                    <td colspan="4" class="text-center py-8 text-gray-500">Tidak ada transaksi pada rentang tanggal ini.</td>
-                </tr>
-                @endforelse
-            </tbody>
-        </table>
-    </div>
-</div>
+@php
+    $formatCurrency = fn ($value) => 'Rp' . number_format($value, 0, ',', '.');
+@endphp
 
-{{-- Tabel Rincian Hutang --}}
-<div class="bg-white rounded-lg shadow-sm p-6">
-    <h3 class="text-xl font-semibold text-gray-900  mb-4">Rincian Hutang</h3>
-    <div class="overflow-x-auto">
-        <table class="w-full text-left">
-            <thead class="border-b">
-                <tr>
-                    <th class="px-6 py-3 text-xs font-semibold tracking-wider text-gray-500 uppercase">Pihak Terkait</th>
-                    <th class="px-6 py-3 text-xs font-semibold tracking-wider text-gray-500 uppercase">Deskripsi</th>
-                    <th class="px-6 py-3 text-xs font-semibold tracking-wider text-gray-500 uppercase text-right">Jumlah</th>
-                    <th class="px-6 py-3 text-xs font-semibold tracking-wider text-gray-500 uppercase text-right">Terbayar</th>
-                    <th class="px-6 py-3 text-xs font-semibold tracking-wider text-gray-500 uppercase text-right">Sisa</th>
-                    <th class="px-6 py-3 text-xs font-semibold tracking-wider text-gray-500 uppercase">Jatuh Tempo</th>
-                    <th class="px-6 py-3 text-xs font-semibold tracking-wider text-gray-500 uppercase">Status</th>
-                </tr>
-            </thead>
-            <tbody class="divide-y">
-                @forelse($debts as $debt)
-                <tr>
-                    <td class="px-6 py-4 text-sm text-gray-500 whitespace-nowrap">{{ $debt->related_party }}</td>
-                    <td class="px-6 py-4 text-sm text-gray-500 whitespace-nowrap">{{ $debt->description }}</td>
-                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-right">Rp{{ number_format($debt->amount, 0, ',', '.') }}</td>
-                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-right text-green-600">Rp{{ number_format($debt->paid_amount, 0, ',', '.') }}</td>
-                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-right text-red-600">Rp{{ number_format($debt->remaining_amount, 0, ',', '.') }}</td>
-                    <td class="px-6 py-4 text-sm font-medium text-gray-900  whitespace-nowrap">{{ \Carbon\Carbon::parse($debt->due_date)->isoFormat('D MMM YYYY') }}</td>
-                    <td class="px-6 py-4 text-sm text-gray-500 whitespace-nowrap">
-                        <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full {{ $debt->status == 'lunas' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' }}">
-                            {{ ucfirst($debt->status) }}
-                        </span>
-                    </td>
-                </tr>
-                @empty
-                <tr>
-                    <td colspan="7" class="text-center py-8 text-gray-500">Tidak ada data hutang pada rentang tanggal ini.</td>
-                </tr>
-                @endforelse
-            </tbody>
-        </table>
+{{-- Detail Laporan --}}
+<div class="mb-10 rounded-2xl bg-white/80 p-6 shadow-sm backdrop-blur" x-data="{ tab: 'cashflow' }">
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+            <h3 class="text-xl font-semibold text-gray-900 ">Detail Laporan</h3>
+            <p class="text-sm text-gray-500">Pilih jenis laporan untuk melihat rincian data keuangan pada periode ini.</p>
+        </div>
+        <div class="inline-flex rounded-full bg-slate-100 p-1">
+            <button
+                type="button"
+                @click="tab = 'cashflow'"
+                :class="tab === 'cashflow' ? 'bg-[#000080] text-white shadow-sm' : 'text-slate-600'"
+                class="rounded-full px-4 py-2 text-sm font-semibold transition"
+            >
+                Pemasukan &amp; Pengeluaran
+            </button>
+            <button
+                type="button"
+                @click="tab = 'debt'"
+                :class="tab === 'debt' ? 'bg-[#000080] text-white shadow-sm' : 'text-slate-600'"
+                class="rounded-full px-4 py-2 text-sm font-semibold transition"
+            >
+                Laporan Hutang
+            </button>
+        </div>
+    </div>
+
+    <div class="mt-6 space-y-6" x-cloak>
+        <div x-show="tab === 'cashflow'" x-transition>
+            <div class="grid gap-6 lg:grid-cols-2">
+                <div class="flex h-full flex-col overflow-hidden rounded-2xl border border-[#000080]/20 bg-white/70 shadow-sm">
+                    <div class="flex items-start justify-between border-b border-[#000080]/10 px-6 py-4">
+                        <div>
+                            <h4 class="text-lg font-semibold text-gray-900 ">Daftar Pemasukan</h4>
+                            <p class="text-xs text-gray-500">Transaksi pemasukan selama rentang tanggal yang dipilih.</p>
+                        </div>
+                        <span class="rounded-full bg-[#000080]/10 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-[#000080]">Total: {{ $formatCurrency($totalPemasukan) }}</span>
+                    </div>
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-[#000080]/15 text-sm">
+                            <thead class="bg-[#000080] text-white">
+                                <tr>
+                                    <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide">Tanggal</th>
+                                    <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide">Kategori</th>
+                                    <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide">Deskripsi</th>
+                                    <th class="px-6 py-3 text-right text-xs font-semibold uppercase tracking-wide">Jumlah</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-[#000080]/10">
+                                @forelse($incomeTransactions as $transaction)
+                                    <tr class="bg-white/70">
+                                        <td class="px-6 py-3 text-sm font-medium text-gray-900 whitespace-nowrap">{{ \Carbon\Carbon::parse($transaction->date)->isoFormat('D MMM YYYY') }}</td>
+                                        <td class="px-6 py-3 text-sm text-gray-600 whitespace-nowrap">{{ $transaction->category?->name }}</td>
+                                        <td class="px-6 py-3 text-sm text-gray-500">{{ $transaction->description }}</td>
+                                        <td class="px-6 py-3 text-right text-sm font-semibold text-emerald-600">{{ $formatCurrency($transaction->amount) }}</td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="4" class="px-6 py-6 text-center text-sm text-gray-500">Tidak ada pemasukan pada periode ini.</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                            <tfoot class="bg-[#000080]/5">
+                                <tr>
+                                    <td colspan="3" class="px-6 py-3 text-right text-xs font-semibold uppercase tracking-wide text-[#000080]">Total Pemasukan</td>
+                                    <td class="px-6 py-3 text-right text-sm font-semibold text-[#000080]">{{ $formatCurrency($totalPemasukan) }}</td>
+                                </tr>
+                            </tfoot>
+                        </table>
+                    </div>
+                </div>
+
+                <div class="flex h-full flex-col overflow-hidden rounded-2xl border border-[#000080]/20 bg-white/70 shadow-sm">
+                    <div class="flex items-start justify-between border-b border-[#000080]/10 px-6 py-4">
+                        <div>
+                            <h4 class="text-lg font-semibold text-gray-900 ">Daftar Pengeluaran</h4>
+                            <p class="text-xs text-gray-500">Transaksi pengeluaran selama rentang tanggal yang dipilih.</p>
+                        </div>
+                        <span class="rounded-full bg-[#000080]/10 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-[#000080]">Total: {{ $formatCurrency($totalPengeluaran) }}</span>
+                    </div>
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-[#000080]/15 text-sm">
+                            <thead class="bg-[#000080] text-white">
+                                <tr>
+                                    <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide">Tanggal</th>
+                                    <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide">Kategori</th>
+                                    <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide">Deskripsi</th>
+                                    <th class="px-6 py-3 text-right text-xs font-semibold uppercase tracking-wide">Jumlah</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-[#000080]/10">
+                                @forelse($expenseTransactions as $transaction)
+                                    <tr class="bg-white/70">
+                                        <td class="px-6 py-3 text-sm font-medium text-gray-900 whitespace-nowrap">{{ \Carbon\Carbon::parse($transaction->date)->isoFormat('D MMM YYYY') }}</td>
+                                        <td class="px-6 py-3 text-sm text-gray-600 whitespace-nowrap">{{ $transaction->category?->name }}</td>
+                                        <td class="px-6 py-3 text-sm text-gray-500">{{ $transaction->description }}</td>
+                                        <td class="px-6 py-3 text-right text-sm font-semibold text-rose-600">{{ $formatCurrency($transaction->amount) }}</td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="4" class="px-6 py-6 text-center text-sm text-gray-500">Tidak ada pengeluaran pada periode ini.</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                            <tfoot class="bg-[#000080]/5">
+                                <tr>
+                                    <td colspan="3" class="px-6 py-3 text-right text-xs font-semibold uppercase tracking-wide text-[#000080]">Total Pengeluaran</td>
+                                    <td class="px-6 py-3 text-right text-sm font-semibold text-[#000080]">{{ $formatCurrency($totalPengeluaran) }}</td>
+                                </tr>
+                            </tfoot>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div x-show="tab === 'debt'" x-transition>
+            <div class="flex flex-col overflow-hidden rounded-2xl border border-[#000080]/20 bg-white/70 shadow-sm">
+                <div class="flex flex-col gap-3 border-b border-[#000080]/10 px-6 py-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                        <h4 class="text-lg font-semibold text-gray-900 ">Rincian Hutang</h4>
+                        <p class="text-xs text-gray-500">Pantau posisi hutang serta progres pembayarannya.</p>
+                    </div>
+                    <div class="flex flex-wrap gap-2">
+                        <span class="rounded-full bg-[#000080]/10 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-[#000080]">Total: {{ $formatCurrency($totalHutang) }}</span>
+                        <span class="rounded-full bg-emerald-100 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700">Terbayar: {{ $formatCurrency($totalPembayaranHutang) }}</span>
+                        <span class="rounded-full bg-rose-100 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-rose-700">Sisa: {{ $formatCurrency($sisaHutang) }}</span>
+                    </div>
+                </div>
+                <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-[#000080]/15 text-sm">
+                        <thead class="bg-[#000080] text-white">
+                            <tr>
+                                <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide">Pihak Terkait</th>
+                                <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide">Deskripsi</th>
+                                <th class="px-6 py-3 text-right text-xs font-semibold uppercase tracking-wide">Jumlah</th>
+                                <th class="px-6 py-3 text-right text-xs font-semibold uppercase tracking-wide">Terbayar</th>
+                                <th class="px-6 py-3 text-right text-xs font-semibold uppercase tracking-wide">Sisa</th>
+                                <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide">Jatuh Tempo</th>
+                                <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide">Status</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-[#000080]/10">
+                            @forelse($debts as $debt)
+                                <tr class="bg-white/70">
+                                    <td class="px-6 py-3 text-sm font-medium text-gray-900 whitespace-nowrap">{{ $debt->related_party }}</td>
+                                    <td class="px-6 py-3 text-sm text-gray-600">{{ $debt->description }}</td>
+                                    <td class="px-6 py-3 text-right text-sm font-semibold text-[#000080]">{{ $formatCurrency($debt->amount) }}</td>
+                                    <td class="px-6 py-3 text-right text-sm font-semibold text-emerald-600">{{ $formatCurrency($debt->paid_amount) }}</td>
+                                    <td class="px-6 py-3 text-right text-sm font-semibold text-rose-600">{{ $formatCurrency($debt->remaining_amount) }}</td>
+                                    <td class="px-6 py-3 text-sm text-gray-600 whitespace-nowrap">{{ \Carbon\Carbon::parse($debt->due_date)->isoFormat('D MMM YYYY') }}</td>
+                                    <td class="px-6 py-3 text-sm font-semibold">
+                                        <span class="inline-flex rounded-full px-3 py-1 text-xs uppercase tracking-wide {{ $debt->status === 'lunas' ? 'bg-emerald-100 text-emerald-700' : 'bg-rose-100 text-rose-700' }}">
+                                            {{ ucfirst($debt->status) }}
+                                        </span>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="7" class="px-6 py-6 text-center text-sm text-gray-500">Tidak ada data hutang pada periode ini.</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                        <tfoot class="bg-[#000080]/5">
+                            <tr>
+                                <td colspan="2" class="px-6 py-3 text-right text-xs font-semibold uppercase tracking-wide text-[#000080]">Ringkasan</td>
+                                <td class="px-6 py-3 text-right text-sm font-semibold text-[#000080]">{{ $formatCurrency($totalHutang) }}</td>
+                                <td class="px-6 py-3 text-right text-sm font-semibold text-[#000080]">{{ $formatCurrency($totalPembayaranHutang) }}</td>
+                                <td class="px-6 py-3 text-right text-sm font-semibold text-[#000080]">{{ $formatCurrency($sisaHutang) }}</td>
+                                <td colspan="2"></td>
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- add a dedicated financial report service to centralize transaction and debt aggregation for exports and the UI
- introduce a styled PDF export option alongside the refreshed Excel template with navy themed tables
- redesign the reports page with tabbed cashflow and debt tables plus improved export controls

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_b_68d9f4da1fc08331bf5817bc93b40801