### PR TITLE
Support configurable debt categories and settlements

### DIFF
--- a/app/Http/Requests/StoreDebtPaymentRequest.php
+++ b/app/Http/Requests/StoreDebtPaymentRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreDebtPaymentRequest extends FormRequest
 {
@@ -25,6 +26,7 @@ class StoreDebtPaymentRequest extends FormRequest
             'payment_amount' => 'required|numeric|min:0',
             'payment_date' => 'nullable|date',
             'notes' => 'nullable|string',
+            'category_id' => ['nullable', 'integer', Rule::exists('categories', 'id')],
         ];
     }
 
@@ -40,6 +42,8 @@ class StoreDebtPaymentRequest extends FormRequest
             'payment_amount.numeric' => 'Jumlah pembayaran harus berupa angka.',
             'payment_amount.min' => 'Jumlah pembayaran tidak boleh kurang dari 0.',
             'payment_date.date' => 'Format tanggal tidak valid.',
+            'category_id.integer' => 'Kategori tidak valid.',
+            'category_id.exists' => 'Kategori tidak ditemukan.',
         ];
     }
 }

--- a/app/Http/Requests/StoreDebtRequest.php
+++ b/app/Http/Requests/StoreDebtRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use App\Models\Debt;
+use Illuminate\Validation\Rule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StoreDebtRequest extends FormRequest
@@ -28,6 +29,16 @@ class StoreDebtRequest extends FormRequest
             'type' => 'required|in:' . Debt::TYPE_PASS_THROUGH . ',' . Debt::TYPE_DOWN_PAYMENT,
             'amount' => 'required|numeric|min:0',
             'due_date' => 'nullable|date',
+            'category_id' => [
+                'required',
+                'integer',
+                Rule::exists('categories', 'id')->where(function ($query) {
+                    $type = $this->input('type');
+                    $expectedCategoryType = $type === Debt::TYPE_DOWN_PAYMENT ? 'pemasukan' : 'pengeluaran';
+
+                    $query->where('type', $expectedCategoryType);
+                }),
+            ],
         ];
     }
 
@@ -49,6 +60,9 @@ class StoreDebtRequest extends FormRequest
             'amount.numeric' => 'Jumlah harus berupa angka.',
             'amount.min' => 'Jumlah tidak boleh kurang dari 0.',
             'due_date.date' => 'Format tanggal tidak valid.',
+            'category_id.required' => 'Kategori wajib dipilih.',
+            'category_id.integer' => 'Kategori tidak valid.',
+            'category_id.exists' => 'Kategori tidak ditemukan atau tidak sesuai dengan tipe.',
         ];
     }
 }

--- a/app/Models/Debt.php
+++ b/app/Models/Debt.php
@@ -22,6 +22,7 @@ class Debt extends Model
         'amount',
         'due_date',
         'status',
+        'category_id',
         'user_id',
     ];
 
@@ -51,5 +52,10 @@ class Debt extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(\App\Models\User::class);
+    }
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class);
     }
 }

--- a/app/Services/DebtService.php
+++ b/app/Services/DebtService.php
@@ -14,7 +14,7 @@ class DebtService
      */
     public function getDebts(Request $request, User $user): LengthAwarePaginator
     {
-        $query = Debt::with('payments')
+        $query = Debt::with(['payments', 'category'])
             ->where('user_id', $user->id)
             ->latest();
 

--- a/database/migrations/2025_09_29_034955_add_category_id_to_debts_table.php
+++ b/database/migrations/2025_09_29_034955_add_category_id_to_debts_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('debts', function (Blueprint $table) {
+            $table->foreignId('category_id')
+                ->nullable()
+                ->after('status')
+                ->constrained()
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('debts', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('category_id');
+        });
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -39,6 +39,7 @@ Route::middleware(['auth', 'role:admin,accountant,staff'])->group(function () {
         ->name('transactions.proof.show');
     Route::resource('transactions', TransactionController::class)->except(['show']);
     Route::resource('categories', CategoryController::class)->except(['create', 'edit', 'show']);
+    Route::post('debts/category-preferences', [DebtController::class, 'updateCategoryPreferences'])->name('debts.category-preferences.update');
     Route::resource('debts', DebtController::class);
     Route::resource('invoices', InvoiceController::class);
 

--- a/tests/Feature/DebtTest.php
+++ b/tests/Feature/DebtTest.php
@@ -2,8 +2,9 @@
 
 namespace Tests\Feature;
 
-use App\Models\User;
+use App\Models\Category;
 use App\Models\Debt;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -16,6 +17,10 @@ class DebtTest extends TestCase
     public function test_user_can_add_pass_through_debt()
     {
         $user = User::factory()->create();
+        $category = Category::create([
+            'name' => 'Operasional',
+            'type' => 'pengeluaran',
+        ]);
 
         $response = $this->actingAs($user)->post('/debts', [
             'description' => 'Pass Through Expense',
@@ -23,6 +28,7 @@ class DebtTest extends TestCase
             'type' => Debt::TYPE_PASS_THROUGH,
             'amount' => 1000,
             'due_date' => now()->addMonth()->toDateString(),
+            'category_id' => $category->id,
         ]);
 
         $response->assertRedirect('/debts');
@@ -33,6 +39,7 @@ class DebtTest extends TestCase
             'type' => Debt::TYPE_PASS_THROUGH,
             'amount' => 1000,
             'status' => Debt::STATUS_BELUM_LUNAS,
+            'category_id' => $category->id,
         ]);
     }
 
@@ -40,6 +47,11 @@ class DebtTest extends TestCase
     {
         $user = User::factory()->create();
         $this->actingAs($user);
+
+        $category = Category::create([
+            'name' => 'Pembayaran Hutang',
+            'type' => 'pengeluaran',
+        ]);
 
         // FIX: Kembali menggunakan create() dan pastikan user_id ada.
         $debt = Debt::create([
@@ -50,11 +62,13 @@ class DebtTest extends TestCase
             'amount' => 1000,
             'status' => Debt::STATUS_BELUM_LUNAS,
             'due_date' => now()->addWeek(),
+            'category_id' => $category->id,
         ]);
 
         // ... sisa kode tes tidak perlu diubah
         $response = $this->post(route('debts.pay', $debt), [
             'payment_amount' => 1000,
+            'category_id' => $category->id,
         ]);
 
         $response->assertRedirect(route('debts.index'));


### PR DESCRIPTION
## Summary
- add a category reference to debts so that settlements use an existing income or expense category
- expose category preferences and selectors in the debt index UI for both creation and payment flows
- validate the new inputs, update transaction generation, and extend tests to cover the new category requirements

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_b_68da01235ef883318536a885daf56a69