### PR TITLE
Revamp invoice status and payment handling

### DIFF
--- a/app/Console/Commands/SendInvoiceReminder.php
+++ b/app/Console/Commands/SendInvoiceReminder.php
@@ -13,7 +13,7 @@ class SendInvoiceReminder extends Command
 
     public function handle(): int
     {
-        $invoices = Invoice::where('status', 'Proses')
+        $invoices = Invoice::whereIn('status', ['belum bayar', 'belum lunas'])
             ->whereDate('due_date', '<=', now()->toDateString())
             ->get();
 

--- a/app/Http/Requests/PublicStoreInvoiceRequest.php
+++ b/app/Http/Requests/PublicStoreInvoiceRequest.php
@@ -2,6 +2,9 @@
 
 namespace App\Http\Requests;
 
+use App\Enums\Role;
+use Illuminate\Validation\Rule;
+
 class PublicStoreInvoiceRequest extends StoreInvoiceRequest
 {
     /**
@@ -12,7 +15,17 @@ class PublicStoreInvoiceRequest extends StoreInvoiceRequest
     public function rules(): array
     {
         return array_merge(parent::rules(), [
-            'customer_service_id' => ['required', 'exists:users,id'],
+            'customer_service_name' => [
+                'required',
+                'string',
+                Rule::exists('users', 'name')->where(function ($query) {
+                    $query->whereIn('role', [
+                        Role::ADMIN->value,
+                        Role::ACCOUNTANT->value,
+                        Role::STAFF->value,
+                    ]);
+                }),
+            ],
         ]);
     }
 
@@ -24,8 +37,8 @@ class PublicStoreInvoiceRequest extends StoreInvoiceRequest
     public function messages(): array
     {
         return array_merge(parent::messages(), [
-            'customer_service_id.required' => 'Pilih customer service yang akan menangani invoice ini.',
-            'customer_service_id.exists' => 'Customer service yang dipilih tidak ditemukan.',
+            'customer_service_name.required' => 'Masukkan nama customer service yang akan menangani invoice ini.',
+            'customer_service_name.exists' => 'Nama customer service tidak ditemukan.',
         ]);
     }
 }

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -46,7 +46,7 @@ class Invoice extends Model
 
     /**
      * The "booted" method of the model.
-     * Secara otomatis membuat transaksi pemasukan ketika status invoice diubah menjadi 'Paid'.
+     * Penetapan token publik dilakukan ketika invoice dibuat.
      */
     protected static function booted()
     {
@@ -54,25 +54,7 @@ class Invoice extends Model
             $invoice->public_token = Str::uuid();
         });
 
-        static::updated(function (Invoice $invoice) {
-            // Cek jika status berubah menjadi 'Paid' dan sebelumnya bukan 'Paid'
-            if ($invoice->isDirty('status') && $invoice->status === 'Paid') {
-                // Cari kategori default untuk pemasukan invoice, misal 'Penjualan Jasa'
-                // Fallback ke kategori pertama jika tidak ditemukan
-                $category = Category::where('name', 'Penjualan Jasa')->orWhere('type', 'pemasukan')->first();
-
-                // Pastikan ada kategori sebelum membuat transaksi
-                if ($category) {
-                    Transaction::create([
-                        'category_id' => $category->id,
-                        'user_id' => auth()->id(), // Gunakan user yang sedang login
-                        'amount' => $invoice->total,
-                        'description' => 'Pembayaran untuk Invoice #' . $invoice->number,
-                        'date' => now(),
-                    ]);
-                }
-            }
-        });
+        // Pencatatan transaksi dipindahkan ke proses pembayaran agar lebih fleksibel
     }
 
     /**

--- a/database/factories/InvoiceFactory.php
+++ b/database/factories/InvoiceFactory.php
@@ -20,7 +20,7 @@ class InvoiceFactory extends Factory
             'client_address' => $this->faker->address,
             'issue_date' => now(),
             'due_date' => $this->faker->dateTimeBetween('+1 week', '+1 month'),
-            'status' => 'Draft',
+            'status' => 'belum bayar',
             'total' => $this->faker->randomFloat(2, 100, 1000),
         ];
     }

--- a/database/migrations/2025_08_30_000002_create_invoices_table.php
+++ b/database/migrations/2025_08_30_000002_create_invoices_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
             $table->string('number')->unique();
             $table->date('issue_date')->nullable();
             $table->date('due_date')->nullable();
-            $table->enum('status', ['Draft', 'Sent', 'Paid', 'Overdue'])->default('Draft');
+            $table->enum('status', ['belum bayar', 'belum lunas', 'lunas'])->default('belum bayar');
             $table->decimal('total', 15, 2)->default(0);
             $table->timestamps();
         });

--- a/database/migrations/2025_09_09_070552_update_status_enum_in_invoices_table.php
+++ b/database/migrations/2025_09_09_070552_update_status_enum_in_invoices_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('invoices', function (Blueprint $table) {
-            $table->enum('status', ['Draft', 'Proses', 'Terbayar', 'Terbayar Sebagian', 'Batal'])->default('Draft')->change();
+            $table->enum('status', ['belum bayar', 'belum lunas', 'lunas'])->default('belum bayar')->change();
         });
     }
 

--- a/resources/views/invoices/index.blade.php
+++ b/resources/views/invoices/index.blade.php
@@ -5,34 +5,40 @@
         </h2>
     </x-slot>
 
-    <div class="py-12" x-data="{ openModal: false, selectedInvoice: null }">
+    @php
+        $categoryOptions = $incomeCategories->map(fn ($category) => [
+            'id' => $category->id,
+            'name' => $category->name,
+        ])->values();
+    @endphp
+    <div class="py-12" x-data="invoicePayments({ categories: @js($categoryOptions), defaultDate: '{{ now()->toDateString() }}' })">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
                 <div class="mb-4">
-                    <a href="{{ route('invoices.create') }}" class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700">{{ __('New Invoice') }}</a>
+                    <a href="{{ route('invoices.create') }}" class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700">Buat Invoices</a>
                 </div>
                 <div class="overflow-x-auto">
                     <table class="w-full text-left">
                         <thead class="border-b">
                             <tr>
-                                <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase">{{ __('Number') }}</th>
-                                <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase">{{ __('Status') }}</th>
-                                <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase">{{ __('Customer Service') }}</th>
-                                <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase text-right">{{ __('Total') }}</th>
-                                <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase text-right">{{ __('Paid Amount') }}</th>
-                                <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase text-right">{{ __('Remaining Amount') }}</th>
-                                <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase text-center">{{ __('Actions') }}</th>
+                                <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase">Nomor</th>
+                                <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase">Status</th>
+                                <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase">Customer Service</th>
+                                <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase text-right">Total</th>
+                                <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase text-right">Uang Muka</th>
+                                <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase text-right">Sisa Pembayaran</th>
+                                <th class="px-6 py-3 text-xs font-semibold text-gray-500 uppercase text-center">Aksi</th>
                             </tr>
                         </thead>
                         <tbody class="divide-y">
                             @foreach ($invoices as $invoice)
                             <tr>
                                 <td class="px-6 py-4">{{ $invoice->number }}</td>
-                                <td class="px-6 py-4">{{ $invoice->status }}</td>
+                                <td class="px-6 py-4">{{ ucwords($invoice->status) }}</td>
                                 <td class="px-6 py-4">{{ $invoice->customerService?->name ?? '-' }}</td>
                                 <td class="px-6 py-4 text-right">Rp {{ number_format($invoice->total, 0, ',', '.') }}</td>
                                 <td class="px-6 py-4 text-right">Rp {{ number_format($invoice->down_payment, 0, ',', '.') }}</td>
-                                <td class="px-6 py-4 text-right">Rp {{ number_format($invoice->total - $invoice->down_payment, 0, ',', '.') }}</td>
+                                <td class="px-6 py-4 text-right">Rp {{ number_format(max($invoice->total - $invoice->down_payment, 0), 0, ',', '.') }}</td>
                                 <td class="px-6 py-4 text-center">
                                     <div class="flex justify-center items-center gap-2">
                                         <a href="{{ route('invoices.pdf', $invoice) }}" class="text-gray-600 hover:text-gray-900 dark:text-white" target="_blank">PDF</a>
@@ -41,14 +47,10 @@
                                             {{ __('Copy Link') }}
                                         </button>
                                         @endif
-                                        @if($invoice->status === 'Draft')
-                                        <form method="POST" action="{{ route('invoices.send', $invoice) }}">
-                                            @csrf
-                                            <button type="submit" class="text-blue-600 hover:text-blue-900">{{ __('Send') }}</button>
-                                        </form>
-                                        @endif
-                                        @if($invoice->status !== 'Paid')
-                                        <button type="button" @click="openModal = true; selectedInvoice = {{ $invoice->id }};" class="text-green-600 hover:text-green-900">{{ __('Record Payment') }}</button>
+                                        @if($invoice->status !== 'lunas')
+                                        <button type="button"
+                                            @click="open({{ $invoice->id }}, {{ (float) $invoice->total }}, {{ (float) $invoice->down_payment }})"
+                                            class="text-green-600 hover:text-green-900">Catat Pembayaran</button>
                                         @endif
                                     </div>
                                 </td>
@@ -66,30 +68,46 @@
         <!-- Modal -->
         <div x-show="openModal" class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
             <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-                <div x-show="openModal" @click.away="openModal = false" class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+                <div x-show="openModal" @click.away="close()" class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
                 <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
                 <div x-show="openModal" @click.stop class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
                     <form :action="'/invoices/' + selectedInvoice + '/pay'" method="POST">
                         @csrf
                         <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
                             <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-white" id="modal-title">
-                                Record Payment
+                                Catat Pembayaran
                             </h3>
-                            <div class="mt-2">
-                                <label for="payment_amount" class="block text-sm font-medium text-gray-700">Payment Amount</label>
-                                <input type="number" name="payment_amount" id="payment_amount" step="0.01" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md">
+                            <p class="mt-1 text-sm text-gray-500">Sisa tagihan saat ini: <span class="font-semibold" x-text="formatCurrency(remaining)"></span></p>
+                            <div class="mt-4">
+                                <label for="payment_amount" class="block text-sm font-medium text-gray-700">Nominal Pembayaran</label>
+                                <input type="number" name="payment_amount" id="payment_amount" step="0.01" min="0.01" :max="remaining"
+                                    x-model="paymentAmount"
+                                    class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md">
                             </div>
-                            <div class="mt-2">
-                                <label for="payment_date" class="block text-sm font-medium text-gray-700">Payment Date</label>
-                                <input type="date" name="payment_date" id="payment_date" class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" value="{{ date('Y-m-d') }}">
+                            <div class="mt-4">
+                                <label for="payment_date" class="block text-sm font-medium text-gray-700">Tanggal Pembayaran</label>
+                                <input type="date" name="payment_date" id="payment_date"
+                                    x-model="paymentDate"
+                                    class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md">
+                            </div>
+                            <div class="mt-4" x-show="willBePaidOff" x-cloak>
+                                <label for="category_id" class="block text-sm font-medium text-gray-700">Kategori Pemasukan</label>
+                                <select name="category_id" id="category_id" x-model="categoryId" :required="willBePaidOff" :disabled="!willBePaidOff"
+                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                    <option value="">Pilih kategori pemasukan</option>
+                                    <template x-for="category in categories" :key="category.id">
+                                        <option :value="category.id" x-text="category.name"></option>
+                                    </template>
+                                </select>
+                                <p class="mt-2 text-xs text-gray-500">Pilih kategori pemasukan untuk mencatat pembayaran lunas.</p>
                             </div>
                         </div>
                         <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
                             <button type="submit" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-blue-600 text-base font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:ml-3 sm:w-auto sm:text-sm">
-                                Save
+                                Simpan
                             </button>
-                            <button @click="openModal = false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
-                                Cancel
+                            <button @click="close()" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
+                                Batal
                             </button>
                         </div>
                     </form>
@@ -130,6 +148,44 @@
                 }
                 document.body.removeChild(textarea);
             }
+        }
+    </script>
+    <script>
+        function invoicePayments(config) {
+            return {
+                openModal: false,
+                selectedInvoice: null,
+                categories: config.categories ?? [],
+                defaultDate: config.defaultDate,
+                total: 0,
+                paid: 0,
+                paymentAmount: '',
+                paymentDate: config.defaultDate,
+                categoryId: '',
+                get remaining() {
+                    const remaining = this.total - this.paid;
+                    return remaining > 0 ? Number(remaining.toFixed(2)) : 0;
+                },
+                get willBePaidOff() {
+                    const amount = Number(this.paymentAmount || 0);
+                    return this.remaining > 0 && amount >= this.remaining;
+                },
+                open(id, total, downPayment) {
+                    this.selectedInvoice = id;
+                    this.total = Number(total || 0);
+                    this.paid = Number(downPayment || 0);
+                    this.paymentAmount = this.remaining > 0 ? this.remaining : '';
+                    this.paymentDate = this.defaultDate;
+                    this.categoryId = '';
+                    this.openModal = true;
+                },
+                close() {
+                    this.openModal = false;
+                },
+                formatCurrency(value) {
+                    return new Intl.NumberFormat('id-ID', { style: 'currency', currency: 'IDR' }).format(value || 0);
+                },
+            };
         }
     </script>
 </x-app-layout>

--- a/resources/views/invoices/pdf.blade.php
+++ b/resources/views/invoices/pdf.blade.php
@@ -108,7 +108,7 @@
                             <div class="flex flex-col items-end text-right text-red-600 space-y-1">
                                 <p><strong>Sub Total:</strong> <span class="ml-2">Rp. {{ number_format($invoice->total, 2, ',', '.') }}</span></p>
                                 <p><strong>Down Payment:</strong> <span class="ml-2">Rp. {{ number_format($invoice->down_payment, 2, ',', '.') }}</span></p>
-                                <p><strong>Keterangan:</strong> <span class="ml-2">{{ $invoice->status ?? 'Menunggu Pembayaran' }}</span></p>
+                                <p><strong>Keterangan:</strong> <span class="ml-2">{{ $invoice->status ? ucwords($invoice->status) : 'Menunggu Pembayaran' }}</span></p>
                             </div>
                         </td>
                     </tr>

--- a/resources/views/invoices/public-create.blade.php
+++ b/resources/views/invoices/public-create.blade.php
@@ -54,15 +54,17 @@
                             </div>
                             <div class="space-y-4">
                                 <div>
-                                    <label for="customer_service_id" class="block text-sm font-medium text-gray-700">Customer Service</label>
-                                    <select name="customer_service_id" id="customer_service_id" class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" required>
-                                        <option value="">Pilih Customer Service</option>
+                                    <label for="customer_service_name" class="block text-sm font-medium text-gray-700">Customer Service</label>
+                                    <input type="text" name="customer_service_name" id="customer_service_name" list="customer-service-options"
+                                        class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                        placeholder="Ketik nama customer service"
+                                        value="{{ old('customer_service_name') }}"
+                                        required>
+                                    <datalist id="customer-service-options">
                                         @foreach ($customerServices as $customerService)
-                                            <option value="{{ $customerService->id }}" @selected(old('customer_service_id') == $customerService->id)>
-                                                {{ $customerService->name }} ({{ ucfirst($customerService->role->value) }})
-                                            </option>
+                                            <option value="{{ $customerService->name }}">{{ $customerService->name }} ({{ ucfirst($customerService->role->value) }})</option>
                                         @endforeach
-                                    </select>
+                                    </datalist>
                                 </div>
                                 <div>
                                     <label for="client_address" class="block text-sm font-medium text-gray-700">Alamat Klien</label>

--- a/tests/Feature/InvoiceTest.php
+++ b/tests/Feature/InvoiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\Category;
 use App\Models\Invoice;
 use App\Models\InvoiceItem;
 use App\Models\User;
@@ -66,16 +67,19 @@ class InvoiceTest extends TestCase
         $this->actingAs($user)->post(route('invoices.send', $invoice));
         $this->assertDatabaseHas('invoices', [
             'id' => $invoice->id,
-            'status' => 'Proses',
+            'status' => 'belum bayar',
         ]);
+
+        $category = Category::factory()->create(['type' => 'pemasukan']);
 
         $this->actingAs($user)->post(route('invoices.pay', $invoice), [
             'payment_amount' => $invoice->total,
             'payment_date' => now()->toDateString(),
+            'category_id' => $category->id,
         ]);
         $this->assertDatabaseHas('invoices', [
             'id' => $invoice->id,
-            'status' => 'Terbayar',
+            'status' => 'lunas',
         ]);
     }
 

--- a/tests/Feature/SendInvoiceReminderCommandTest.php
+++ b/tests/Feature/SendInvoiceReminderCommandTest.php
@@ -18,25 +18,25 @@ class SendInvoiceReminderCommandTest extends TestCase
         $due = Invoice::factory()->create([
             'user_id' => $user->id,
             'due_date' => now()->subDay(),
-            'status' => 'Proses',
+            'status' => 'belum bayar',
         ]);
 
         $future = Invoice::factory()->create([
             'user_id' => $user->id,
             'due_date' => now()->addDay(),
-            'status' => 'Proses',
+            'status' => 'belum bayar',
         ]);
 
-        $draft = Invoice::factory()->create([
+        $paid = Invoice::factory()->create([
             'user_id' => $user->id,
             'due_date' => now(),
-            'status' => 'Draft',
+            'status' => 'lunas',
         ]);
 
         $this->artisan('invoices:reminder')
             ->expectsOutput("Reminder sent for invoice {$due->number}")
             ->doesntExpectOutput("Reminder sent for invoice {$future->number}")
-            ->doesntExpectOutput("Reminder sent for invoice {$draft->number}")
+            ->doesntExpectOutput("Reminder sent for invoice {$paid->number}")
             ->assertExitCode(0);
     }
 }


### PR DESCRIPTION
## Summary
- align invoice statuses and persistence logic with the new "belum bayar", "belum lunas", dan "lunas" states, including down payment handling and PDF output adjustments
- refresh the invoices index experience with localized labels, a customer-service datalist, and a modal that requires income category selection when an invoice is paid off
- update migrations, factories, console reminder command, and feature tests to reflect the revised status workflow

## Testing
- php artisan test *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_b_68dcd9b074b88331a9220ca3659d7ffc