### PR TITLE
Add standalone customer service records for invoices

### DIFF
--- a/app/Http/Controllers/CustomerServiceController.php
+++ b/app/Http/Controllers/CustomerServiceController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CustomerService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class CustomerServiceController extends Controller
+{
+    public function create(): View
+    {
+        $customerServices = CustomerService::orderBy('name')->paginate(10);
+
+        return view('customer-services.create', compact('customerServices'));
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['nullable', 'email', 'max:255'],
+            'phone' => ['nullable', 'string', 'max:50'],
+        ]);
+
+        CustomerService::create($data);
+
+        return redirect()
+            ->route('customer-services.create')
+            ->with('status', 'Customer service berhasil ditambahkan.');
+    }
+}

--- a/app/Http/Requests/PublicStoreInvoiceRequest.php
+++ b/app/Http/Requests/PublicStoreInvoiceRequest.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Requests;
 
-use App\Enums\Role;
 use Illuminate\Validation\Rule;
 
 class PublicStoreInvoiceRequest extends StoreInvoiceRequest
@@ -18,13 +17,8 @@ class PublicStoreInvoiceRequest extends StoreInvoiceRequest
             'customer_service_name' => [
                 'required',
                 'string',
-                Rule::exists('users', 'name')->where(function ($query) {
-                    $query->whereIn('role', [
-                        Role::ADMIN->value,
-                        Role::ACCOUNTANT->value,
-                        Role::STAFF->value,
-                    ]);
-                }),
+                'max:255',
+                Rule::exists('customer_services', 'name'),
             ],
         ]);
     }

--- a/app/Http/Requests/StoreInvoiceRequest.php
+++ b/app/Http/Requests/StoreInvoiceRequest.php
@@ -22,6 +22,7 @@ class StoreInvoiceRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'customer_service_id' => ['nullable', 'exists:customer_services,id'],
             'client_name' => ['required', 'string', 'max:255'],
             'client_email' => ['required', 'email', 'max:255'],
             'client_address' => ['required', 'string'],
@@ -47,6 +48,7 @@ class StoreInvoiceRequest extends FormRequest
             'client_address.required' => 'Alamat klien wajib diisi.',
             'issue_date.date' => 'Format tanggal terbit tidak valid.',
             'due_date.date' => 'Format tanggal jatuh tempo tidak valid.',
+            'customer_service_id.exists' => 'Customer service yang dipilih tidak valid.',
             'items.*.description.required' => 'Deskripsi item wajib diisi.',
             'items.*.description.string' => 'Deskripsi item harus berupa teks.',
             'items.*.quantity.required' => 'Kuantitas item wajib diisi.',

--- a/app/Models/CustomerService.php
+++ b/app/Models/CustomerService.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+
+class CustomerService extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'phone',
+        'user_id',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function invoices(): HasMany
+    {
+        return $this->hasMany(Invoice::class);
+    }
+}

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -30,6 +30,8 @@ class Invoice extends Model
         'client_address',
         'down_payment',
         'payment_date',
+        'customer_service_id',
+        'customer_service_name',
     ];
 
     /**
@@ -66,6 +68,11 @@ class Invoice extends Model
     }
 
     public function customerService(): BelongsTo
+    {
+        return $this->belongsTo(CustomerService::class);
+    }
+
+    public function owner(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');
     }

--- a/database/migrations/2025_09_10_000000_create_customer_services_table.php
+++ b/database/migrations/2025_09_10_000000_create_customer_services_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('customer_services', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->nullable();
+            $table->string('phone')->nullable();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('customer_services');
+    }
+};

--- a/database/migrations/2025_09_10_000001_add_customer_service_id_to_invoices_table.php
+++ b/database/migrations/2025_09_10_000001_add_customer_service_id_to_invoices_table.php
@@ -1,0 +1,89 @@
+<?php
+
+use App\Enums\Role;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->foreignId('customer_service_id')
+                ->nullable()
+                ->after('user_id')
+                ->constrained('customer_services')
+                ->nullOnDelete();
+            $table->string('customer_service_name')->nullable()->after('customer_service_id');
+        });
+
+        DB::transaction(function () {
+            $users = DB::table('users')
+                ->whereIn('role', [
+                    Role::ADMIN->value,
+                    Role::ACCOUNTANT->value,
+                    Role::STAFF->value,
+                ])
+                ->get();
+
+            $existingCustomerServices = DB::table('customer_services')
+                ->pluck('id', 'user_id');
+
+            foreach ($users as $user) {
+                if ($existingCustomerServices->has($user->id)) {
+                    continue;
+                }
+
+                $customerServiceId = DB::table('customer_services')->insertGetId([
+                    'name' => $user->name,
+                    'email' => $user->email,
+                    'phone' => null,
+                    'user_id' => $user->id,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+
+                $existingCustomerServices->put($user->id, $customerServiceId);
+            }
+
+            $customerServices = DB::table('customer_services')
+                ->select('id', 'name', 'user_id')
+                ->get()
+                ->keyBy('user_id');
+
+            $invoices = DB::table('invoices')->get();
+
+            foreach ($invoices as $invoice) {
+                $customerService = $customerServices->get($invoice->user_id);
+
+                DB::table('invoices')
+                    ->where('id', $invoice->id)
+                    ->update([
+                        'customer_service_id' => $customerService->id ?? null,
+                        'customer_service_name' => $customerService->name ?? null,
+                    ]);
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('invoices')->update([
+            'customer_service_id' => null,
+            'customer_service_name' => null,
+        ]);
+
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('customer_service_id');
+            $table->dropColumn('customer_service_name');
+        });
+    }
+};

--- a/resources/views/customer-services/create.blade.php
+++ b/resources/views/customer-services/create.blade.php
@@ -1,0 +1,85 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-white leading-tight">
+            {{ __('Customer Service') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6">
+                    @if (session('status'))
+                        <div class="mb-4 rounded border border-green-200 bg-green-50 p-4 text-green-700">
+                            {{ session('status') }}
+                        </div>
+                    @endif
+
+                    <form action="{{ route('customer-services.store') }}" method="POST" class="space-y-4">
+                        @csrf
+                        <div>
+                            <label for="name" class="block text-sm font-medium text-gray-700">Nama Customer Service</label>
+                            <input type="text" name="name" id="name" value="{{ old('name') }}" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm" required>
+                            @error('name')
+                                <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                            @enderror
+                        </div>
+                        <div>
+                            <label for="email" class="block text-sm font-medium text-gray-700">Email</label>
+                            <input type="email" name="email" id="email" value="{{ old('email') }}" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm">
+                            @error('email')
+                                <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                            @enderror
+                        </div>
+                        <div>
+                            <label for="phone" class="block text-sm font-medium text-gray-700">Nomor Telepon</label>
+                            <input type="text" name="phone" id="phone" value="{{ old('phone') }}" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm">
+                            @error('phone')
+                                <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                            @enderror
+                        </div>
+                        <div class="flex justify-end">
+                            <button type="submit" class="inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700">
+                                Simpan
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            <div class="mt-8 bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6">
+                    <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-4">Daftar Customer Service</h3>
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nama</th>
+                                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
+                                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Telepon</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                @forelse ($customerServices as $customerService)
+                                    <tr>
+                                        <td class="px-4 py-2 text-sm text-gray-900">{{ $customerService->name }}</td>
+                                        <td class="px-4 py-2 text-sm text-gray-500">{{ $customerService->email ?? '-' }}</td>
+                                        <td class="px-4 py-2 text-sm text-gray-500">{{ $customerService->phone ?? '-' }}</td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="3" class="px-4 py-4 text-center text-sm text-gray-500">Belum ada data customer service.</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="mt-4">
+                        {{ $customerServices->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/invoices/create.blade.php
+++ b/resources/views/invoices/create.blade.php
@@ -11,6 +11,27 @@
                 <form action="{{ route('invoices.store') }}" method="POST" class="p-6">
                     @csrf
 
+                    {{-- Customer Service --}}
+                    <div class="mb-6">
+                        <label for="customer_service_id" class="block text-sm font-medium text-gray-700">Customer Service</label>
+                        <div class="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
+                            <select name="customer_service_id" id="customer_service_id" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
+                                <option value="">Pilih customer service</option>
+                                @foreach($customerServices as $customerService)
+                                    <option value="{{ $customerService->id }}" @selected(old('customer_service_id') == $customerService->id)>
+                                        {{ $customerService->name }}
+                                    </option>
+                                @endforeach
+                            </select>
+                            <a href="{{ route('customer-services.create') }}" class="inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700">
+                                Tambah Customer Service
+                            </a>
+                        </div>
+                        @error('customer_service_id')
+                            <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                        @enderror
+                    </div>
+
                     {{-- Informasi Klien --}}
                     <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-4">Informasi Klien</h3>
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">

--- a/resources/views/invoices/edit.blade.php
+++ b/resources/views/invoices/edit.blade.php
@@ -6,6 +6,17 @@
         @csrf
         @method('PUT')
         <div>
+            <label for="customer_service_id">Customer Service</label>
+            <select name="customer_service_id" id="customer_service_id">
+                <option value="">Pilih customer service</option>
+                @foreach($customerServices as $customerService)
+                    <option value="{{ $customerService->id }}" @selected(old('customer_service_id', $invoice->customer_service_id) == $customerService->id)>
+                        {{ $customerService->name }}
+                    </option>
+                @endforeach
+            </select>
+        </div>
+        <div>
             <label for="client_name">Client Name</label>
             <input type="text" name="client_name" id="client_name" value="{{ $invoice->client_name }}">
         </div>

--- a/resources/views/invoices/index.blade.php
+++ b/resources/views/invoices/index.blade.php
@@ -14,8 +14,9 @@
     <div class="py-12" x-data="invoicePayments({ categories: @js($categoryOptions), defaultDate: '{{ now()->toDateString() }}' })">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
-                <div class="mb-4">
+                <div class="mb-4 flex flex-wrap gap-2">
                     <a href="{{ route('invoices.create') }}" class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700">Buat Invoices</a>
+                    <a href="{{ route('customer-services.create') }}" class="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700">Tambah Customer Service</a>
                 </div>
                 <div class="overflow-x-auto">
                     <table class="w-full text-left">
@@ -35,7 +36,7 @@
                             <tr>
                                 <td class="px-6 py-4">{{ $invoice->number }}</td>
                                 <td class="px-6 py-4">{{ ucwords($invoice->status) }}</td>
-                                <td class="px-6 py-4">{{ $invoice->customerService?->name ?? '-' }}</td>
+                                <td class="px-6 py-4">{{ $invoice->customer_service_name ?? $invoice->customerService?->name ?? '-' }}</td>
                                 <td class="px-6 py-4 text-right">Rp {{ number_format($invoice->total, 0, ',', '.') }}</td>
                                 <td class="px-6 py-4 text-right">Rp {{ number_format($invoice->down_payment, 0, ',', '.') }}</td>
                                 <td class="px-6 py-4 text-right">Rp {{ number_format(max($invoice->total - $invoice->down_payment, 0), 0, ',', '.') }}</td>

--- a/resources/views/invoices/pdf.blade.php
+++ b/resources/views/invoices/pdf.blade.php
@@ -76,7 +76,7 @@
                 <p><strong>Inv No :</strong> {{ $invoice->number }}</p>
                 <p><strong>Inv Date :</strong> {{ $invoice->issue_date->format('d/m/Y') }}</p>
                 <p><strong>Kepada :</strong> {{ $invoice->client_name }}</p>
-                <p><strong>Customer Service :</strong> {{ $invoice->customerService?->name ?? '-' }}</p>
+                <p><strong>Customer Service :</strong> {{ $invoice->customer_service_name ?? $invoice->customerService?->name ?? '-' }}</p>
             </div>
         </section>
 

--- a/resources/views/invoices/public-create.blade.php
+++ b/resources/views/invoices/public-create.blade.php
@@ -62,7 +62,7 @@
                                         required>
                                     <datalist id="customer-service-options">
                                         @foreach ($customerServices as $customerService)
-                                            <option value="{{ $customerService->name }}">{{ $customerService->name }} ({{ ucfirst($customerService->role->value) }})</option>
+                                            <option value="{{ $customerService->name }}">{{ $customerService->name }}</option>
                                         @endforeach
                                     </datalist>
                                 </div>

--- a/resources/views/invoices/show.blade.php
+++ b/resources/views/invoices/show.blade.php
@@ -6,6 +6,7 @@
     <p>Client Name: {{ $invoice->client_name }}</p>
     <p>Client Email: {{ $invoice->client_email }}</p>
     <p>Client Address: {{ $invoice->client_address }}</p>
+    <p>Customer Service: {{ $invoice->customer_service_name ?? $invoice->customerService?->name ?? '-' }}</p>
     <p>Issue Date: {{ $invoice->issue_date->format('Y-m-d') }}</p>
     <p>Due Date: {{ $invoice->due_date->format('Y-m-d') }}</p>
     <p>Total: {{ $invoice->total }}</p>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\CategoryController;
+use App\Http\Controllers\CustomerServiceController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\DebtController;
 use App\Http\Controllers\InvoiceController;
@@ -45,6 +46,8 @@ Route::middleware(['auth', 'role:admin,accountant,staff'])->group(function () {
     Route::post('debts/category-preferences', [DebtController::class, 'updateCategoryPreferences'])->name('debts.category-preferences.update');
     Route::resource('debts', DebtController::class);
     Route::resource('invoices', InvoiceController::class);
+    Route::get('customer-services/create', [CustomerServiceController::class, 'create'])->name('customer-services.create');
+    Route::post('customer-services', [CustomerServiceController::class, 'store'])->name('customer-services.store');
 
     // Route untuk Aksi Spesifik
     // Invoicing


### PR DESCRIPTION
## Summary
- introduce a dedicated customer service model, controller, and management page
- link invoices to customer service records and persist the selected contact name
- update invoice forms, validation, and public flow to use the new customer service dataset

## Testing
- php artisan test *(fails: vendor/autoload.php missing in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dcdf7b5c448331abfdc95474a46cc7