### PR TITLE
Allow accountants to store invoice payments

### DIFF
--- a/app/Policies/InvoicePolicy.php
+++ b/app/Policies/InvoicePolicy.php
@@ -40,6 +40,6 @@ class InvoicePolicy
 
     public function storePayment(User $user, Invoice $invoice): bool
     {
-        return $user->id === $invoice->user_id;
+        return $user->id === $invoice->user_id || in_array($user->role, [Role::ADMIN, Role::ACCOUNTANT], true);
     }
 }


### PR DESCRIPTION
## Summary
- allow admins and accountants to record invoice payments via policy update

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68de3f6e720083318468b13bc3918146