### PR TITLE
Add planned down payment support to invoices

### DIFF
--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -376,6 +376,9 @@ class InvoiceController extends Controller
                 'issue_date' => $data['issue_date'] ?? $invoice->issue_date ?? now(),
                 'due_date' => $data['due_date'] ?? null,
                 'total' => $this->calculateInvoiceTotal($items),
+                'down_payment_due' => array_key_exists('down_payment_due', $data)
+                    ? (isset($data['down_payment_due']) ? (float) $data['down_payment_due'] : null)
+                    : $invoice->down_payment_due,
             ]);
 
             $invoice->items()->delete();
@@ -427,6 +430,9 @@ class InvoiceController extends Controller
                 'due_date' => $data['due_date'] ?? null,
                 'status' => 'belum bayar',
                 'total' => $this->calculateInvoiceTotal($items),
+                'down_payment_due' => array_key_exists('down_payment_due', $data)
+                    ? (isset($data['down_payment_due']) ? (float) $data['down_payment_due'] : null)
+                    : null,
             ]);
 
             foreach ($items as $item) {

--- a/app/Http/Requests/StoreInvoiceRequest.php
+++ b/app/Http/Requests/StoreInvoiceRequest.php
@@ -29,6 +29,7 @@ class StoreInvoiceRequest extends FormRequest
             'client_address' => ['required', 'string'],
             'issue_date' => ['nullable', 'date'],
             'due_date' => ['nullable', 'date'],
+            'down_payment_due' => ['nullable', 'numeric', 'min:0'],
             'items.*.description' => ['required', 'string'],
             'items.*.quantity' => ['required', 'integer', 'min:1'],
             'items.*.price' => ['required', 'numeric'],
@@ -54,6 +55,8 @@ class StoreInvoiceRequest extends FormRequest
             'client_address.required' => 'Alamat klien wajib diisi.',
             'issue_date.date' => 'Format tanggal terbit tidak valid.',
             'due_date.date' => 'Format tanggal jatuh tempo tidak valid.',
+            'down_payment_due.numeric' => 'Rencana down payment harus berupa angka.',
+            'down_payment_due.min' => 'Rencana down payment minimal 0.',
             'customer_service_id.exists' => 'Customer service yang dipilih tidak valid.',
             'items.*.description.required' => 'Deskripsi item wajib diisi.',
             'items.*.description.string' => 'Deskripsi item harus berupa teks.',
@@ -90,9 +93,18 @@ class StoreInvoiceRequest extends FormRequest
             $whatsapp = preg_replace('/[^\d+]/', '', $whatsapp);
         }
 
+        $downPaymentDue = $this->input('down_payment_due');
+        if (isset($downPaymentDue)) {
+            $normalizedDownPaymentDue = preg_replace('/[^\d,.-]/', '', (string) $downPaymentDue);
+            $normalizedDownPaymentDue = str_replace('.', '', $normalizedDownPaymentDue);
+            $normalizedDownPaymentDue = str_replace(',', '.', $normalizedDownPaymentDue);
+            $downPaymentDue = $normalizedDownPaymentDue === '' ? null : $normalizedDownPaymentDue;
+        }
+
         $this->merge([
             'items' => $items->toArray(),
             'client_whatsapp' => $whatsapp,
+            'down_payment_due' => $downPaymentDue,
         ]);
     }
 }

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -30,6 +30,7 @@ class Invoice extends Model
         'client_whatsapp',
         'client_address',
         'down_payment',
+        'down_payment_due',
         'payment_date',
         'customer_service_id',
         'customer_service_name',
@@ -45,6 +46,7 @@ class Invoice extends Model
         'due_date' => 'date',
         'total' => 'decimal:2',
         'down_payment' => 'decimal:2',
+        'down_payment_due' => 'decimal:2',
     ];
 
     /**

--- a/database/migrations/2025_10_05_000003_add_down_payment_due_to_invoices_table.php
+++ b/database/migrations/2025_10_05_000003_add_down_payment_due_to_invoices_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            if (! Schema::hasColumn('invoices', 'down_payment_due')) {
+                $table->decimal('down_payment_due', 15, 2)->nullable()->after('down_payment');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            if (Schema::hasColumn('invoices', 'down_payment_due')) {
+                $table->dropColumn('down_payment_due');
+            }
+        });
+    }
+};

--- a/resources/views/invoices/create.blade.php
+++ b/resources/views/invoices/create.blade.php
@@ -131,6 +131,16 @@
                         <button type="button" id="add-item" class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700">Tambah Item</button>
                     </div>
 
+                    {{-- Rencana Down Payment --}}
+                    <div class="mt-6">
+                        <label for="down_payment_due" class="block text-sm font-medium text-gray-700">Rencana Down Payment</label>
+                        <input type="text" name="down_payment_due" id="down_payment_due" value="{{ old('down_payment_due') }}" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm price-input" placeholder="Contoh: 5.000.000">
+                        <p class="mt-1 text-xs text-gray-500">Opsional. Nilai ini akan diusulkan sebagai nominal pembayaran awal ketika mencatat pembayaran.</p>
+                        @error('down_payment_due')
+                            <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                        @enderror
+                    </div>
+
                     {{-- Total --}}
                     <div class="mt-6 pt-6 border-t border-gray-200 flex justify-end">
                         <div class="text-right">

--- a/resources/views/invoices/edit.blade.php
+++ b/resources/views/invoices/edit.blade.php
@@ -126,6 +126,22 @@
                 </div>
             </div>
 
+            <div>
+                <label for="down_payment_due" class="block text-sm font-medium text-gray-700">Rencana Down Payment</label>
+                <input
+                    type="text"
+                    name="down_payment_due"
+                    id="down_payment_due"
+                    value="{{ old('down_payment_due', $invoice->down_payment_due !== null ? (string) (int) round($invoice->down_payment_due) : '') }}"
+                    class="mt-1 block w-full border-gray-300 rounded-md shadow-sm price-input"
+                    placeholder="Contoh: 5.000.000"
+                >
+                <p class="mt-1 text-xs text-gray-500">Opsional. Nilai ini akan diusulkan sebagai nominal pembayaran awal ketika mencatat pembayaran.</p>
+                @error('down_payment_due')
+                    <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                @enderror
+            </div>
+
             <div class="flex justify-end">
                 <button type="submit" class="px-6 py-3 text-base font-medium text-white bg-green-600 rounded-lg hover:bg-green-700">Perbarui Invoice</button>
             </div>

--- a/resources/views/invoices/index.blade.php
+++ b/resources/views/invoices/index.blade.php
@@ -45,7 +45,7 @@
                                         <a href="{{ route('invoices.pdf', $invoice) }}" class="text-gray-600 hover:text-gray-900 dark:text-white" target="_blank">PDF</a>
                                         @if($invoice->status !== 'lunas')
                                         <button type="button"
-                                            @click="open({{ $invoice->id }}, {{ (float) $invoice->total }}, {{ (float) $invoice->down_payment }})"
+                                            @click="open({{ $invoice->id }}, {{ (float) $invoice->total }}, {{ (float) $invoice->down_payment }}, {{ (float) ($invoice->down_payment_due ?? 0) }})"
                                             class="text-green-600 hover:text-green-900">Catat Pembayaran</button>
                                         @endif
                                     </div>
@@ -120,6 +120,7 @@
                 defaultDate: config.defaultDate,
                 total: 0,
                 paid: 0,
+                plannedDownPayment: 0,
                 paymentAmount: '',
                 paymentDate: config.defaultDate,
                 categoryId: '',
@@ -131,11 +132,20 @@
                     const amount = Number(this.paymentAmount || 0);
                     return this.remaining > 0 && amount >= this.remaining;
                 },
-                open(id, total, downPayment) {
+                open(id, total, downPayment, plannedDownPayment = 0) {
                     this.selectedInvoice = id;
                     this.total = Number(total || 0);
                     this.paid = Number(downPayment || 0);
-                    this.paymentAmount = this.remaining > 0 ? this.remaining : '';
+                    this.plannedDownPayment = Number(plannedDownPayment || 0);
+                    const remaining = this.remaining;
+                    if (remaining > 0) {
+                        const suggested = this.plannedDownPayment > 0
+                            ? Math.min(remaining, this.plannedDownPayment)
+                            : remaining;
+                        this.paymentAmount = suggested > 0 ? Number(suggested.toFixed(2)) : '';
+                    } else {
+                        this.paymentAmount = '';
+                    }
                     this.paymentDate = this.defaultDate;
                     this.categoryId = '';
                     this.openModal = true;

--- a/resources/views/invoices/pdf.blade.php
+++ b/resources/views/invoices/pdf.blade.php
@@ -107,6 +107,9 @@
                         <td class="px-3 py-3" colspan="2">
                             <div class="flex flex-col items-end text-right text-red-600 space-y-1">
                                 <p><strong>Sub Total:</strong> <span class="ml-2">Rp. {{ number_format($invoice->total, 2, ',', '.') }}</span></p>
+                                @if(! is_null($invoice->down_payment_due))
+                                    <p><strong>Rencana Down Payment:</strong> <span class="ml-2">Rp. {{ number_format($invoice->down_payment_due, 2, ',', '.') }}</span></p>
+                                @endif
                                 <p><strong>Down Payment:</strong> <span class="ml-2">Rp. {{ number_format($invoice->down_payment, 2, ',', '.') }}</span></p>
                                 <p><strong>Keterangan:</strong> <span class="ml-2">{{ $invoice->status ? ucwords($invoice->status) : 'Menunggu Pembayaran' }}</span></p>
                             </div>

--- a/resources/views/invoices/public-create.blade.php
+++ b/resources/views/invoices/public-create.blade.php
@@ -158,6 +158,15 @@
                             <p id="total-amount" class="text-2xl font-bold text-indigo-600">Rp 0</p>
                         </div>
 
+                        <div>
+                            <label for="down_payment_due" class="block text-sm font-medium text-gray-700">Rencana Down Payment</label>
+                            <input type="text" name="down_payment_due" id="down_payment_due" class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 price-input" value="{{ old('down_payment_due') }}" placeholder="Contoh: 5.000.000">
+                            <p class="mt-1 text-xs text-gray-500">Opsional. Nilai ini akan diusulkan sebagai nominal pembayaran awal ketika mencatat pembayaran.</p>
+                            @error('down_payment_due')
+                                <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
+                            @enderror
+                        </div>
+
                         <div class="flex justify-end">
                             <button type="submit" class="inline-flex items-center justify-center rounded-xl bg-green-600 px-6 py-3 text-base font-semibold text-white shadow-lg hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2">
                                 Buat & Unduh Invoice


### PR DESCRIPTION
## Summary
- add a new down_payment_due column on invoices and expose it through the model and validation rules
- accept, normalize, and display the planned down payment across invoice creation, editing, PDF export, and the public form
- prefill the payment modal with the planned down payment amount to speed up recording initial payments

## Testing
- `php artisan test` *(fails: missing vendor/autoload.php in container)*

------
https://chatgpt.com/codex/tasks/task_b_68df3926b28c8331ba1264592e7cb99a