### PR TITLE
Add role-gated invoice tabs with access codes

### DIFF
--- a/app/Enums/Role.php
+++ b/app/Enums/Role.php
@@ -7,4 +7,17 @@ enum Role: string
     case ADMIN = 'admin';
     case ACCOUNTANT = 'accountant';
     case STAFF = 'staff';
+    case CUSTOMER_SERVICE = 'customer_service';
+    case SETTLEMENT_ADMIN = 'settlement_admin';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::ADMIN => 'Admin',
+            self::ACCOUNTANT => 'Accountant',
+            self::STAFF => 'Staff',
+            self::CUSTOMER_SERVICE => 'Customer Service',
+            self::SETTLEMENT_ADMIN => 'Admin Pelunasan',
+        };
+    }
 }

--- a/app/Http/Controllers/AccessCodeController.php
+++ b/app/Http/Controllers/AccessCodeController.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\Role;
+use App\Models\AccessCode;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+class AccessCodeController extends Controller
+{
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'user_id' => ['nullable', 'exists:users,id'],
+            'role' => ['required', 'string', 'in:' . implode(',', array_map(fn (Role $role) => $role->value, Role::cases()))],
+            'expires_at' => ['nullable', 'date', 'after:now'],
+        ]);
+
+        $role = Role::from($validated['role']);
+
+        $user = null;
+        if (! empty($validated['user_id'])) {
+            $user = User::find($validated['user_id']);
+        }
+
+        $rawCode = strtoupper(Str::random(10));
+        $publicId = (string) Str::uuid();
+
+        $accessCode = AccessCode::create([
+            'public_id' => $publicId,
+            'user_id' => $user?->id,
+            'role' => $role,
+            'code_hash' => Hash::make($rawCode),
+            'expires_at' => $validated['expires_at'] ?? null,
+        ]);
+
+        $displayCode = $publicId . ':' . $rawCode;
+
+        return back()->with('access_code_generated', [
+            'code' => $displayCode,
+            'role' => $accessCode->role->label(),
+            'user' => $user?->name,
+        ]);
+    }
+
+    public function verify(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'code' => ['required', 'string'],
+        ]);
+
+        $user = $request->user();
+        [$publicId, $rawCode] = array_pad(explode(':', $request->input('code'), 2), 2, null);
+
+        if (! $publicId || ! $rawCode) {
+            return back()->withErrors([
+                'code' => 'Format kode akses tidak valid.',
+            ]);
+        }
+
+        $accessCode = AccessCode::where('public_id', $publicId)->first();
+
+        if (! $accessCode || ! Hash::check($rawCode, $accessCode->code_hash)) {
+            return back()->withErrors([
+                'code' => 'Kode akses tidak ditemukan atau sudah tidak berlaku.',
+            ]);
+        }
+
+        if ($accessCode->used_at) {
+            return back()->withErrors([
+                'code' => 'Kode akses sudah digunakan.',
+            ]);
+        }
+
+        if ($accessCode->isExpired()) {
+            return back()->withErrors([
+                'code' => 'Kode akses sudah kedaluwarsa.',
+            ]);
+        }
+
+        if ($accessCode->role !== $user->role) {
+            return back()->withErrors([
+                'code' => 'Kode akses tidak sesuai dengan peran Anda.',
+            ]);
+        }
+
+        if ($accessCode->user_id && $accessCode->user_id !== $user->id) {
+            return back()->withErrors([
+                'code' => 'Kode akses tidak terhubung dengan akun Anda.',
+            ]);
+        }
+
+        $accessCode->forceFill([
+            'used_at' => now(),
+            'used_by' => $user->id,
+        ])->save();
+
+        $verifiedRoles = collect(session('verified_access_roles', []))
+            ->push($user->role->value)
+            ->unique()
+            ->values()
+            ->all();
+
+        session(['verified_access_roles' => $verifiedRoles]);
+
+        return redirect()
+            ->route('invoices.index')
+            ->with('access_code_status', 'Kode akses berhasil diverifikasi untuk ' . $user->role->label() . '.');
+    }
+}

--- a/app/Models/AccessCode.php
+++ b/app/Models/AccessCode.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\Role;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AccessCode extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'public_id',
+        'user_id',
+        'role',
+        'code_hash',
+        'used_at',
+        'used_by',
+        'expires_at',
+    ];
+
+    protected $casts = [
+        'role' => Role::class,
+        'used_at' => 'datetime',
+        'expires_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function usedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'used_by');
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->expires_at !== null && now()->greaterThan($this->expires_at);
+    }
+}

--- a/app/Policies/InvoicePolicy.php
+++ b/app/Policies/InvoicePolicy.php
@@ -40,6 +40,22 @@ class InvoicePolicy
 
     public function storePayment(User $user, Invoice $invoice): bool
     {
-        return $user->id === $invoice->user_id || in_array($user->role, [Role::ADMIN, Role::ACCOUNTANT], true);
+        return $user->id === $invoice->user_id
+            || in_array($user->role, [Role::ADMIN, Role::ACCOUNTANT, Role::CUSTOMER_SERVICE], true);
+    }
+
+    public function viewDownPaymentTab(User $user): bool
+    {
+        return in_array($user->role, [Role::ADMIN, Role::CUSTOMER_SERVICE], true);
+    }
+
+    public function viewPayInFullTab(User $user): bool
+    {
+        return in_array($user->role, [Role::ADMIN, Role::CUSTOMER_SERVICE], true);
+    }
+
+    public function viewSettlementTab(User $user): bool
+    {
+        return in_array($user->role, [Role::ADMIN, Role::SETTLEMENT_ADMIN], true);
     }
 }

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
-            $table->enum('role', ['admin', 'accountant', 'staff'])->default('staff');
+            $table->enum('role', ['admin', 'accountant', 'staff', 'customer_service', 'settlement_admin'])->default('staff');
             $table->rememberToken();
             $table->timestamps();
         });

--- a/database/migrations/2025_09_10_000001_add_customer_service_id_to_invoices_table.php
+++ b/database/migrations/2025_09_10_000001_add_customer_service_id_to_invoices_table.php
@@ -28,6 +28,8 @@ return new class extends Migration
                     Role::ADMIN->value,
                     Role::ACCOUNTANT->value,
                     Role::STAFF->value,
+                    Role::CUSTOMER_SERVICE->value,
+                    Role::SETTLEMENT_ADMIN->value,
                 ])
                 ->get();
 

--- a/database/migrations/2025_09_20_000200_update_roles_enum.php
+++ b/database/migrations/2025_09_20_000200_update_roles_enum.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::getConnection()->getDriverName() === 'sqlite') {
+            return;
+        }
+
+        DB::statement("
+            ALTER TABLE users
+            MODIFY COLUMN role ENUM('admin','accountant','staff','customer_service','settlement_admin')
+            DEFAULT 'staff'
+        ");
+    }
+
+    public function down(): void
+    {
+        if (Schema::getConnection()->getDriverName() === 'sqlite') {
+            return;
+        }
+
+        DB::statement("
+            ALTER TABLE users
+            MODIFY COLUMN role ENUM('admin','accountant','staff')
+            DEFAULT 'staff'
+        ");
+    }
+};

--- a/database/migrations/2025_09_20_000210_create_access_codes_table.php
+++ b/database/migrations/2025_09_20_000210_create_access_codes_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('access_codes', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('public_id')->unique();
+            $table->foreignId('user_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->string('role');
+            $table->string('code_hash');
+            $table->timestamp('used_at')->nullable();
+            $table->foreignId('used_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('access_codes');
+    }
+};

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Seeder;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use App\Enums\Role;
+use App\Models\AccessCode;
 
 class UserSeeder extends Seeder
 {
@@ -14,9 +15,13 @@ class UserSeeder extends Seeder
      */
     public function run() :void{
         // hapus user yang mungkin sudah ada dengan email yang sama
-        User::where('email', 'admin@vodeco.co.id')->delete();
-        User::where('email', 'staff@vodeco.co.id')->delete();
-        User::where('email', 'accountant@vodeco.co.id')->delete();
+        User::whereIn('email', [
+            'admin@vodeco.co.id',
+            'staff@vodeco.co.id',
+            'accountant@vodeco.co.id',
+            'cs@vodeco.co.id',
+            'pelunasan@vodeco.co.id',
+        ])->delete();
 
         // Buat User Admin baru
         User::create([
@@ -38,6 +43,38 @@ class UserSeeder extends Seeder
             'email' => 'accountant@vodeco.co.id',
             'password' => Hash::make('masukaja'),
             'role' => Role::ACCOUNTANT,
+        ]);
+
+        $customerService = User::create([
+            'name' => 'Customer Service',
+            'email' => 'cs@vodeco.co.id',
+            'password' => Hash::make('masukaja'),
+            'role' => Role::CUSTOMER_SERVICE,
+        ]);
+
+        $settlementAdmin = User::create([
+            'name' => 'Admin Pelunasan',
+            'email' => 'pelunasan@vodeco.co.id',
+            'password' => Hash::make('masukaja'),
+            'role' => Role::SETTLEMENT_ADMIN,
+        ]);
+
+        $this->seedAccessCode($customerService, Role::CUSTOMER_SERVICE, '11111111-1111-4111-8111-111111111111', 'CS-ACCESS-001');
+        $this->seedAccessCode($settlementAdmin, Role::SETTLEMENT_ADMIN, '22222222-2222-4222-8222-222222222222', 'PELUNASAN-001');
+    }
+
+    private function seedAccessCode(User $user, Role $role, string $publicId, string $rawCode): void
+    {
+        AccessCode::where('public_id', $publicId)->delete();
+
+        AccessCode::create([
+            'public_id' => $publicId,
+            'user_id' => $user->id,
+            'role' => $role,
+            'code_hash' => Hash::make($rawCode),
+            'used_at' => null,
+            'used_by' => null,
+            'expires_at' => now()->addMonths(3),
         ]);
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\AccessCodeController;
 use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\CustomerServiceController;
 use App\Http\Controllers\DashboardController;
@@ -36,7 +37,11 @@ Route::get('/invoices/view/{token}', [InvoiceController::class, 'showPublic'])->
 
 // Menggunakan middleware 'auth' untuk memastikan hanya user yang sudah login
 // yang bisa mengakses halaman-halaman ini.
-Route::middleware(['auth', 'role:admin,accountant,staff'])->group(function () {
+Route::post('/access-codes/verify', [AccessCodeController::class, 'verify'])
+    ->middleware('auth')
+    ->name('access-codes.verify');
+
+Route::middleware(['auth', 'role:admin,accountant,staff,customer_service,settlement_admin'])->group(function () {
     // Dashboard
     Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
 
@@ -96,6 +101,7 @@ Route::middleware(['auth', 'role:admin,accountant,staff'])->group(function () {
 // Route Khusus untuk Admin - Manajemen User
 Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::resource('users', UserController::class)->except(['show']);
+    Route::post('access-codes', [AccessCodeController::class, 'store'])->name('access-codes.store');
 });
 
 Route::middleware(['auth', 'role:admin'])->prefix('admin')->name('admin.')->group(function () {

--- a/tests/Feature/AccessCodeTest.php
+++ b/tests/Feature/AccessCodeTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\Role;
+use App\Models\AccessCode;
+use App\Models\Invoice;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class AccessCodeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_customer_service_requires_access_code_before_viewing_tabs(): void
+    {
+        $user = User::factory()->create(['role' => Role::CUSTOMER_SERVICE]);
+        Invoice::factory()->create(['user_id' => $user->id, 'down_payment_due' => 100000, 'down_payment' => 0]);
+
+        $publicId = (string) Str::uuid();
+        $rawCode = 'CS-UNIT-001';
+
+        AccessCode::create([
+            'public_id' => $publicId,
+            'user_id' => $user->id,
+            'role' => Role::CUSTOMER_SERVICE,
+            'code_hash' => Hash::make($rawCode),
+        ]);
+
+        $this->actingAs($user);
+
+        $this->get(route('invoices.index'))
+            ->assertOk()
+            ->assertDontSee('Down Payment');
+
+        $this->post(route('access-codes.verify'), ['code' => $publicId . ':' . $rawCode])
+            ->assertRedirect(route('invoices.index'));
+
+        $response = $this->get(route('invoices.index'));
+        $response->assertOk();
+        $tabStates = $response->viewData('tabStates');
+        $this->assertTrue($tabStates['down-payment']['unlocked']);
+        $this->assertTrue($tabStates['pay-in-full']['unlocked']);
+    }
+
+    public function test_settlement_admin_needs_access_code_for_pelunasan_tab(): void
+    {
+        $user = User::factory()->create(['role' => Role::SETTLEMENT_ADMIN]);
+        Invoice::factory()->create(['user_id' => $user->id, 'status' => 'belum lunas']);
+
+        $publicId = (string) Str::uuid();
+        $rawCode = 'PELUNASAN-UNIT-1';
+
+        AccessCode::create([
+            'public_id' => $publicId,
+            'user_id' => $user->id,
+            'role' => Role::SETTLEMENT_ADMIN,
+            'code_hash' => Hash::make($rawCode),
+        ]);
+
+        $this->actingAs($user);
+
+        $response = $this->get(route('invoices.index'));
+        $response->assertOk();
+        $this->assertFalse($response->viewData('tabStates')['settlement']['unlocked']);
+
+        $this->post(route('access-codes.verify'), ['code' => $publicId . ':' . $rawCode])
+            ->assertRedirect(route('invoices.index'));
+
+        $this->assertEquals(['settlement_admin'], session('verified_access_roles'));
+        $this->assertTrue(Gate::forUser($user)->allows('viewSettlementTab', Invoice::class));
+
+        $response = $this->get(route('invoices.index'));
+
+        $response->assertOk();
+        $tabStates = $response->viewData('tabStates');
+        $this->assertTrue($tabStates['settlement']['unlocked']);
+        $this->assertSame('Pelunasan', $tabStates['settlement']['label']);
+    }
+
+    public function test_admin_can_view_tabs_without_access_code(): void
+    {
+        $admin = User::factory()->create(['role' => Role::ADMIN]);
+        Invoice::factory()->create(['user_id' => $admin->id, 'down_payment_due' => 50000, 'down_payment' => 0]);
+
+        $this->actingAs($admin);
+
+        $response = $this->get(route('invoices.index'));
+        $response->assertOk();
+        $tabStates = $response->viewData('tabStates');
+        $this->assertTrue($tabStates['down-payment']['unlocked']);
+        $this->assertTrue($tabStates['pay-in-full']['unlocked']);
+        $this->assertTrue($tabStates['settlement']['unlocked']);
+    }
+}


### PR DESCRIPTION
## Summary
- extend the role enum, database schema, and seeding to cover Customer Service and Admin Pelunasan roles with default access codes
- add access code storage plus controller and routing to generate and verify one-time tokens tied to user roles
- update invoice policies, controller logic, and UI to require validated codes per tab and add coverage tests for the new guards

## Testing
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_b_68df4811c5208331954818e969416d27