### PR TITLE
Refactor invoice forms into reusable tab component

### DIFF
--- a/resources/views/invoices/create.blade.php
+++ b/resources/views/invoices/create.blade.php
@@ -20,7 +20,7 @@
                         'name' => $category->name,
                     ])->values();
                 @endphp
-                <form action="{{ route('invoices.store') }}" method="POST" class="p-6" id="invoice-form" data-category-options='@json($categoryOptions)'>
+                <form action="{{ route('invoices.store') }}" method="POST" class="p-6" id="invoice-form">
                     @csrf
 
                     {{-- Customer Service --}}
@@ -83,134 +83,25 @@
                     </div>
 
                     {{-- Item Invoice --}}
-                    <div x-data="{
-                        activeTab: '{{ old('transaction_type', 'down_payment') }}',
-                        setTab(tab) {
-                            this.activeTab = tab;
-                            window.dispatchEvent(new CustomEvent('transaction-tab-changed', { detail: tab }));
-                        },
-                        tabClass(tab) {
-                            return this.activeTab === tab
-                                ? 'px-4 py-2 text-sm font-semibold rounded-lg bg-blue-600 text-white'
-                                : 'px-4 py-2 text-sm font-medium rounded-lg bg-gray-100 text-gray-700 hover:bg-gray-200';
-                        }
-                    }" x-init="window.dispatchEvent(new CustomEvent('transaction-tab-changed', { detail: activeTab }))" class="mt-8">
-                        <input type="hidden" name="transaction_type" id="transaction_type" x-model="activeTab">
-
-                        <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-4">Jenis Transaksi</h3>
-                        <div class="flex flex-wrap gap-3">
-                            <button type="button" :class="tabClass('down_payment')" @click="setTab('down_payment')">Down Payment</button>
-                            <button type="button" :class="tabClass('full_payment')" @click="setTab('full_payment')">Bayar Lunas</button>
-                            <button type="button" :class="tabClass('settlement')" @click="setTab('settlement')">Pelunasan</button>
-                        </div>
-
-                        <div class="mt-6" x-show="activeTab === 'down_payment'" x-cloak>
-                            <label for="down_payment_due" class="block text-sm font-medium text-gray-700">Nominal Down Payment</label>
-                            <input type="text" name="down_payment_due" id="down_payment_due" value="{{ old('down_payment_due') }}" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm price-input" placeholder="Contoh: 5.000.000" data-transaction-scope="down-payment" :required="activeTab === 'down_payment'" :disabled="activeTab !== 'down_payment'">
-                            <p class="mt-1 text-xs text-gray-500">Nominal DP wajib diisi untuk transaksi Down Payment.</p>
-                            @error('down_payment_due')
-                                <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                            @enderror
-                        </div>
-
-                        <div class="mt-6" x-show="activeTab !== 'settlement'" x-cloak>
-                            <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-4">Item</h3>
-                            <div id="invoice-items" class="space-y-4">
-                                @foreach($oldItems as $index => $item)
-                                    <div class="grid grid-cols-12 gap-4 invoice-item bg-gray-50 p-4 rounded-lg">
-                                        <div class="col-span-12">
-                                            <label class="block text-sm font-medium text-gray-700">Deskripsi</label>
-                                            <textarea name="items[{{ $index }}][description]" rows="3" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm description" data-transaction-scope="line-item" required>{{ $item['description'] ?? '' }}</textarea>
-                                            @error('items.' . $index . '.description')
-                                                <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                                            @enderror
-                                        </div>
-                                        <div class="col-span-12 md:col-span-4">
-                                            <label class="block text-sm font-medium text-gray-700">Kategori</label>
-                                            <select name="items[{{ $index }}][category_id]" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm category-select" data-transaction-scope="line-item" required>
-                                                <option value="">Pilih kategori pemasukan</option>
-                                                @foreach($incomeCategories as $category)
-                                                    <option value="{{ $category->id }}" @selected(($item['category_id'] ?? '') == $category->id)>{{ $category->name }}</option>
-                                                @endforeach
-                                            </select>
-                                            @error('items.' . $index . '.category_id')
-                                                <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                                            @enderror
-                                        </div>
-                                        <div class="col-span-6 md:col-span-3">
-                                            <label class="block text-sm font-medium text-gray-700">Kuantitas</label>
-                                            <input type="number" name="items[{{ $index }}][quantity]" value="{{ $item['quantity'] ?? 1 }}" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm quantity" data-transaction-scope="line-item" min="1" required>
-                                            @error('items.' . $index . '.quantity')
-                                                <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                                            @enderror
-                                        </div>
-                                        <div class="col-span-6 md:col-span-3">
-                                            <label class="block text-sm font-medium text-gray-700">Harga Satuan</label>
-                                            <input type="text" name="items[{{ $index }}][price]" value="{{ $item['price'] ?? '' }}" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm price-input" data-transaction-scope="line-item" required>
-                                            @error('items.' . $index . '.price')
-                                                <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                                            @enderror
-                                        </div>
-                                        <div class="col-span-12 md:col-span-2 flex items-end justify-end">
-                                            <button type="button" class="text-red-500 hover:text-red-700 remove-item">Hapus</button>
-                                        </div>
-                                    </div>
-                                @endforeach
-                            </div>
-
-                            <div class="mt-4 flex items-center justify-between">
-                                <button type="button" id="add-item" class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700">Tambah Item</button>
-                            </div>
-                        </div>
-
-                        <div class="mt-6" x-show="activeTab === 'settlement'" x-cloak>
-                            <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-4">Detail Pelunasan</h3>
-                            <div class="space-y-6">
-                                <div>
-                                    <label for="settlement_invoice_number" class="block text-sm font-medium text-gray-700">Nomor Invoice</label>
-                                    <input type="text" name="settlement_invoice_number" id="settlement_invoice_number" value="{{ old('settlement_invoice_number') }}" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" data-transaction-scope="settlement" data-settlement-required="true">
-                                    @error('settlement_invoice_number')
-                                        <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                                    @enderror
-                                </div>
-                                <div>
-                                    <label for="settlement_remaining_balance" class="block text-sm font-medium text-gray-700">Sisa Tagihan</label>
-                                    <input type="text" name="settlement_remaining_balance" id="settlement_remaining_balance" value="{{ old('settlement_remaining_balance') }}" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm price-input" placeholder="Contoh: 2.500.000" data-transaction-scope="settlement" data-settlement-required="true">
-                                    @error('settlement_remaining_balance')
-                                        <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                                    @enderror
-                                </div>
-                                <div>
-                                    <label for="settlement_paid_amount" class="block text-sm font-medium text-gray-700">Nominal Dibayarkan</label>
-                                    <input type="text" name="settlement_paid_amount" id="settlement_paid_amount" value="{{ old('settlement_paid_amount') }}" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm price-input" placeholder="Contoh: 1.500.000" data-transaction-scope="settlement" data-settlement-required="true">
-                                    @error('settlement_paid_amount')
-                                        <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                                    @enderror
-                                </div>
-                                <div>
-                                    <span class="block text-sm font-medium text-gray-700 mb-2">Status Pelunasan</span>
-                                    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-6">
-                                        <label class="inline-flex items-center gap-2 text-sm text-gray-700">
-                                            <input type="radio" name="settlement_payment_status" value="paid_full" @checked(old('settlement_payment_status') === 'paid_full') data-transaction-scope="settlement" data-settlement-required="true">
-                                            <span>Bayar Lunas</span>
-                                        </label>
-                                        <label class="inline-flex items-center gap-2 text-sm text-gray-700">
-                                            <input type="radio" name="settlement_payment_status" value="paid_partial" @checked(old('settlement_payment_status') === 'paid_partial') data-transaction-scope="settlement" data-settlement-required="true">
-                                            <span>Bayar Sebagian</span>
-                                        </label>
-                                    </div>
-                                    @error('settlement_payment_status')
-                                        <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                                    @enderror
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="mt-6 pt-6 border-t border-gray-200 flex justify-end" x-show="activeTab !== 'settlement'" x-cloak>
-                            <div class="text-right">
-                                <p class="text-lg font-medium text-gray-900 dark:text-white">Total: <span id="total-amount">Rp 0</span></p>
-                            </div>
-                        </div>
+                    <div class="mt-8">
+                        <x-invoice.transaction-tabs
+                            form-id="invoice-form"
+                            :items="$oldItems"
+                            :category-options="$categoryOptions"
+                            :default-transaction="old('transaction_type', 'down_payment')"
+                            variant="internal"
+                            down-payment-field-label="Nominal Down Payment"
+                            down-payment-placeholder="Contoh: 5.000.000"
+                            down-payment-help="Nominal DP wajib diisi untuk transaksi Down Payment."
+                            :down-payment-required="true"
+                            add-item-button-label="Tambah Item"
+                            total-label="Total"
+                            :down-payment-value="old('down_payment_due')"
+                            :settlement-invoice-number="old('settlement_invoice_number')"
+                            :settlement-remaining-balance="old('settlement_remaining_balance')"
+                            :settlement-paid-amount="old('settlement_paid_amount')"
+                            :settlement-payment-status="old('settlement_payment_status')"
+                        />
                     </div>
 
 
@@ -222,164 +113,4 @@
         </div>
     </div>
 
-    @push('scripts')
-    <script>
-        document.addEventListener('DOMContentLoaded', function () {
-            const invoiceForm = document.getElementById('invoice-form');
-            const categoryOptions = JSON.parse(invoiceForm.dataset.categoryOptions || '[]');
-            let itemIndex = {{ count($oldItems) }};
-
-            const invoiceItemsContainer = document.getElementById('invoice-items');
-            const totalAmountElement = document.getElementById('total-amount');
-            const addItemButton = document.getElementById('add-item');
-            const transactionTypeInput = document.getElementById('transaction_type');
-
-            function applyTransactionScope(transactionType) {
-                const scope = transactionType || 'down_payment';
-
-                invoiceForm.querySelectorAll('[data-transaction-scope]').forEach(function (input) {
-                    const targetScope = input.dataset.transactionScope;
-
-                    if (targetScope === 'settlement') {
-                        const enable = scope === 'settlement';
-                        input.disabled = !enable;
-                        if (input.dataset.settlementRequired === 'true') {
-                            input.required = enable;
-                        }
-                        if (!enable && input.type === 'radio') {
-                            input.checked = false;
-                        }
-                    } else if (targetScope === 'down-payment') {
-                        const enable = scope === 'down_payment';
-                        input.disabled = !enable;
-                        input.required = enable;
-                    } else if (targetScope === 'line-item') {
-                        input.disabled = scope === 'settlement';
-                    }
-                });
-
-                if (addItemButton) {
-                    const isDisabled = scope === 'settlement';
-                    addItemButton.disabled = isDisabled;
-                    addItemButton.classList.toggle('opacity-50', isDisabled);
-                    addItemButton.classList.toggle('cursor-not-allowed', isDisabled);
-                }
-            }
-
-            function formatPrice(input) {
-                const raw = (input.value || '').replace(/\D/g, '');
-                input.dataset.rawValue = raw;
-                input.value = raw ? raw.replace(/\B(?=(\d{3})+(?!\d))/g, '.') : '';
-            }
-
-            function initPriceInput(input) {
-                formatPrice(input);
-                input.addEventListener('input', function () {
-                    formatPrice(input);
-                    updateTotal();
-                });
-                input.addEventListener('blur', function () {
-                    formatPrice(input);
-                });
-            }
-
-            function updateTotal() {
-                if (!invoiceItemsContainer || !totalAmountElement) {
-                    return;
-                }
-                let total = 0;
-                document.querySelectorAll('#invoice-items .invoice-item').forEach(function (item) {
-                    const quantityValue = item.querySelector('.quantity')?.value || '0';
-                    const priceInput = item.querySelector('.price-input');
-                    const quantity = parseInt(quantityValue, 10) || 0;
-                    const price = parseInt(priceInput?.dataset.rawValue || '0', 10) || 0;
-                    total += quantity * price;
-                });
-
-                totalAmountElement.textContent = new Intl.NumberFormat('id-ID', { style: 'currency', currency: 'IDR' }).format(total || 0);
-            }
-
-            function buildCategoryOptions(selected = '') {
-                return ['<option value="">Pilih kategori pemasukan</option>'].concat(
-                    categoryOptions.map(function (option) {
-                        const isSelected = String(option.id) === String(selected);
-                        return `<option value="${option.id}"${isSelected ? ' selected' : ''}>${option.name}</option>`;
-                    })
-                ).join('');
-            }
-
-            document.querySelectorAll('.price-input').forEach(initPriceInput);
-            document.querySelectorAll('.quantity').forEach(function (input) {
-                input.addEventListener('input', updateTotal);
-            });
-
-            if (addItemButton && invoiceItemsContainer) {
-                addItemButton.addEventListener('click', function () {
-                    const wrapper = document.createElement('div');
-                    wrapper.className = 'grid grid-cols-12 gap-4 invoice-item bg-gray-50 p-4 rounded-lg';
-                    wrapper.innerHTML = `
-                        <div class="col-span-12">
-                            <textarea name="items[${itemIndex}][description]" rows="3" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm description" placeholder="Deskripsi" data-transaction-scope="line-item" required></textarea>
-                        </div>
-                        <div class="col-span-12 md:col-span-4">
-                            <select name="items[${itemIndex}][category_id]" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm category-select" data-transaction-scope="line-item" required>
-                                ${buildCategoryOptions(categoryOptions[0]?.id ?? '')}
-                            </select>
-                        </div>
-                        <div class="col-span-6 md:col-span-3">
-                            <input type="number" name="items[${itemIndex}][quantity]" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm quantity" data-transaction-scope="line-item" value="1" min="1" required>
-                        </div>
-                        <div class="col-span-6 md:col-span-3">
-                            <input type="text" name="items[${itemIndex}][price]" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm price-input" data-transaction-scope="line-item" required>
-                        </div>
-                        <div class="col-span-12 md:col-span-2 flex items-end justify-end">
-                            <button type="button" class="text-red-500 hover:text-red-700 remove-item">Hapus</button>
-                        </div>
-                    `;
-
-                    invoiceItemsContainer.appendChild(wrapper);
-
-                    wrapper.querySelectorAll('.price-input').forEach(initPriceInput);
-                    wrapper.querySelectorAll('.quantity').forEach(function (input) {
-                        input.addEventListener('input', updateTotal);
-                    });
-
-                    itemIndex++;
-                    applyTransactionScope(transactionTypeInput?.value || 'down_payment');
-                    updateTotal();
-                });
-
-                invoiceItemsContainer.addEventListener('click', function (event) {
-                    if (event.target.classList.contains('remove-item')) {
-                        const item = event.target.closest('.invoice-item');
-                        if (item) {
-                            item.remove();
-                            updateTotal();
-                        }
-                    }
-                });
-            }
-
-            invoiceForm.addEventListener('submit', function () {
-                const scope = transactionTypeInput?.value || 'down_payment';
-                applyTransactionScope(scope);
-                document.querySelectorAll('.price-input').forEach(function (input) {
-                    if (input.disabled) {
-                        return;
-                    }
-                    const raw = input.dataset.rawValue || '';
-                    input.value = raw;
-                });
-            });
-
-            window.addEventListener('transaction-tab-changed', function (event) {
-                applyTransactionScope(event.detail);
-                updateTotal();
-            });
-
-            applyTransactionScope(transactionTypeInput?.value || 'down_payment');
-            updateTotal();
-        });
-    </script>
-    @endpush
 </x-app-layout>

--- a/resources/views/invoices/public-create.blade.php
+++ b/resources/views/invoices/public-create.blade.php
@@ -49,13 +49,7 @@
                         </div>
                     @else
                         @php
-                            $transactionLabels = [
-                                'down_payment' => 'Down Payment',
-                                'full_payment' => 'Bayar Lunas',
-                                'settlement' => 'Pelunasan',
-                            ];
-
-                            $allowedTransactions = array_values(array_intersect(array_keys($transactionLabels), $allowedTransactionTypes));
+                            $allowedTransactions = array_values(array_intersect(['down_payment', 'full_payment', 'settlement'], $allowedTransactionTypes));
                             $defaultTransaction = old('transaction_type');
 
                             if (! $defaultTransaction || ! in_array($defaultTransaction, $allowedTransactions, true)) {
@@ -99,23 +93,21 @@
                                 Passphrase aktif tidak memiliki tipe transaksi yang diizinkan. Hubungi administrator untuk memperbarui konfigurasi.
                             </div>
                         @else
-                            <form action="{{ route('invoices.public.store') }}" method="POST" class="space-y-10" id="invoice-form" data-category-options='@json($categoryOptions)' data-default-tab="{{ $defaultTransaction }}"
+                            <form action="{{ route('invoices.public.store') }}" method="POST" class="space-y-10" id="invoice-form"
                                 x-data="{
                                     activeTab: '{{ $defaultTransaction }}',
-                                    setTab(tab) {
-                                        this.activeTab = tab;
-                                        window.dispatchEvent(new CustomEvent('transaction-tab-changed', { detail: tab }));
+                                    init() {
+                                        window.addEventListener('invoice-transaction-tab-changed', (event) => {
+                                            if (!event.detail || !event.detail.tab) {
+                                                return;
+                                            }
+
+                                            this.activeTab = event.detail.tab;
+                                        });
                                     },
-                                    tabClass(tab) {
-                                        return this.activeTab === tab
-                                            ? 'px-4 py-2 text-sm font-semibold rounded-lg bg-indigo-600 text-white'
-                                            : 'px-4 py-2 text-sm font-medium rounded-lg bg-gray-100 text-gray-700 hover:bg-gray-200';
-                                    }
-                                }"
-                                x-init="window.dispatchEvent(new CustomEvent('transaction-tab-changed', { detail: activeTab }))">
+                                }">
                                 @csrf
                                 <input type="hidden" name="passphrase_token" value="{{ $passphraseToken }}">
-                                <input type="hidden" name="transaction_type" id="transaction_type" x-model="activeTab">
 
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                                     <div class="space-y-4">
@@ -142,149 +134,48 @@
                                         </div>
                                     </div>
                                     <div class="space-y-4">
-                                        <div>
-                                            <h2 class="text-sm font-medium text-gray-700 mb-2">Jenis Transaksi</h2>
-                                            <div class="flex flex-wrap gap-2">
-                                                @foreach ($allowedTransactions as $type)
-                                                    <button type="button" @click="setTab('{{ $type }}')" :class="tabClass('{{ $type }}')">
-                                                        {{ $transactionLabels[$type] }}
-                                                    </button>
+                                        <div x-show="activeTab !== 'settlement'" x-cloak>
+                                            <label for="customer_service_name" class="block text-sm font-medium text-gray-700">Customer Service</label>
+                                            <input type="text" name="customer_service_name" id="customer_service_name" list="customer-service-options" class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="Ketik nama customer service" value="{{ old('customer_service_name') }}" :required="activeTab !== 'settlement'" :disabled="activeTab === 'settlement'">
+                                            <datalist id="customer-service-options">
+                                                @foreach ($customerServices as $customerService)
+                                                    <option value="{{ $customerService->name }}">{{ $customerService->name }}</option>
                                                 @endforeach
-                                            </div>
-
-                                            <div class="mt-6 space-y-4">
-                                                <div x-show="activeTab !== 'settlement'" x-cloak>
-                                                    <label for="customer_service_name" class="block text-sm font-medium text-gray-700">Customer Service</label>
-                                                    <input type="text" name="customer_service_name" id="customer_service_name" list="customer-service-options" class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="Ketik nama customer service" value="{{ old('customer_service_name') }}" :required="activeTab !== 'settlement'" :disabled="activeTab === 'settlement'">
-                                                    <datalist id="customer-service-options">
-                                                        @foreach ($customerServices as $customerService)
-                                                            <option value="{{ $customerService->name }}">{{ $customerService->name }}</option>
-                                                        @endforeach
-                                                    </datalist>
-                                                    @error('customer_service_name')
-                                                        <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                                                    @enderror
-                                                </div>
-
-                                                <div>
-                                                    <label for="client_address" class="block text-sm font-medium text-gray-700">Alamat Klien</label>
-                                                    <textarea name="client_address" id="client_address" rows="6" class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" :required="activeTab !== 'settlement'" :disabled="activeTab === 'settlement'">{{ old('client_address') }}</textarea>
-                                                    @error('client_address')
-                                                        <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                                                    @enderror
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div>
-                                    <div x-show="activeTab !== 'settlement'" x-cloak class="space-y-4">
-                                        <div class="flex items-center justify-between">
-                                            <h2 class="text-lg font-semibold text-gray-900">Daftar Item</h2>
-                                            <button type="button" id="add-item" class="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
-                                                + Tambah Item
-                                            </button>
-                                        </div>
-
-                                        <div id="invoice-items" class="space-y-4">
-                                            @foreach ($oldItems as $index => $item)
-                                                <div class="grid grid-cols-12 gap-4 invoice-item bg-gray-50 p-4 rounded-xl">
-                                                    <div class="col-span-12 md:col-span-4">
-                                                        <label class="block text-sm font-medium text-gray-700">Deskripsi</label>
-                                                        <textarea name="items[{{ $index }}][description]" rows="3" class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 description" required>{{ $item['description'] ?? '' }}</textarea>
-                                                        @error('items.' . $index . '.description')
-                                                            <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                                                        @enderror
-                                                    </div>
-                                                    <div class="col-span-12 md:col-span-3">
-                                                        <label class="block text-sm font-medium text-gray-700">Kategori</label>
-                                                        <select name="items[{{ $index }}][category_id]" class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 category-select" required>
-                                                            <option value="">Pilih kategori pemasukan</option>
-                                                            @foreach ($incomeCategories as $category)
-                                                                <option value="{{ $category->id }}" @selected(($item['category_id'] ?? '') == $category->id)>{{ $category->name }}</option>
-                                                            @endforeach
-                                                        </select>
-                                                        @error('items.' . $index . '.category_id')
-                                                            <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                                                        @enderror
-                                                    </div>
-                                                    <div class="col-span-6 md:col-span-2">
-                                                        <label class="block text-sm font-medium text-gray-700">Kuantitas</label>
-                                                        <input type="number" name="items[{{ $index }}][quantity]" class="quantity mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" value="{{ $item['quantity'] ?? 1 }}" min="1" required>
-                                                        @error('items.' . $index . '.quantity')
-                                                            <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                                                        @enderror
-                                                    </div>
-                                                    <div class="col-span-6 md:col-span-2">
-                                                        <label class="block text-sm font-medium text-gray-700">Harga Satuan</label>
-                                                        <input type="text" name="items[{{ $index }}][price]" class="price-input mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" value="{{ $item['price'] ?? '' }}" required>
-                                                        @error('items.' . $index . '.price')
-                                                            <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                                                        @enderror
-                                                    </div>
-                                                    <div class="col-span-12 md:col-span-1 flex items-end justify-end">
-                                                        <button type="button" class="remove-item text-sm font-semibold text-red-600 hover:text-red-700">Hapus</button>
-                                                    </div>
-                                                </div>
-                                            @endforeach
-                                        </div>
-
-                                        <div>
-                                            <label for="down_payment_due" class="block text-sm font-medium text-gray-700">Rencana Down Payment</label>
-                                            <input type="text" name="down_payment_due" id="down_payment_due" class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 price-input" value="{{ old('down_payment_due') }}" placeholder="Contoh: 5.000.000" :disabled="activeTab !== 'down_payment'">
-                                            <p class="mt-1 text-xs text-gray-500">Opsional. Nilai ini akan diusulkan sebagai nominal pembayaran awal ketika mencatat pembayaran.</p>
-                                            @error('down_payment_due')
+                                            </datalist>
+                                            @error('customer_service_name')
                                                 <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
                                             @enderror
                                         </div>
 
-                                        <div class="flex flex-col items-end gap-2 border-t border-gray-200 pt-6">
-                                            <p class="text-lg font-semibold text-gray-900">Total Invoice</p>
-                                            <p id="total-amount" class="text-2xl font-bold text-indigo-600">Rp 0</p>
-                                        </div>
-                                    </div>
-
-                                    <div x-show="activeTab === 'settlement'" x-cloak class="space-y-6">
                                         <div>
-                                            <label for="settlement_invoice_number" class="block text-sm font-medium text-gray-700">Nomor Invoice</label>
-                                            <input type="text" name="settlement_invoice_number" id="settlement_invoice_number" value="{{ old('settlement_invoice_number') }}" class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
-                                            @error('settlement_invoice_number')
-                                                <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                                            @enderror
-                                        </div>
-                                        <div>
-                                            <label for="settlement_remaining_balance" class="block text-sm font-medium text-gray-700">Sisa Tagihan</label>
-                                            <input type="text" name="settlement_remaining_balance" id="settlement_remaining_balance" value="{{ old('settlement_remaining_balance') }}" class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 price-input" placeholder="Contoh: 2.500.000">
-                                            @error('settlement_remaining_balance')
-                                                <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                                            @enderror
-                                        </div>
-                                        <div>
-                                            <label for="settlement_paid_amount" class="block text-sm font-medium text-gray-700">Nominal Dibayarkan</label>
-                                            <input type="text" name="settlement_paid_amount" id="settlement_paid_amount" value="{{ old('settlement_paid_amount') }}" class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 price-input" placeholder="Contoh: 1.500.000">
-                                            @error('settlement_paid_amount')
-                                                <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
-                                            @enderror
-                                        </div>
-                                        <div>
-                                            <span class="block text-sm font-medium text-gray-700 mb-2">Status Pelunasan</span>
-                                            <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-6">
-                                                <label class="inline-flex items-center gap-2 text-sm text-gray-700">
-                                                    <input type="radio" name="settlement_payment_status" value="paid_full" @checked(old('settlement_payment_status') === 'paid_full')>
-                                                    <span>Bayar Lunas</span>
-                                                </label>
-                                                <label class="inline-flex items-center gap-2 text-sm text-gray-700">
-                                                    <input type="radio" name="settlement_payment_status" value="paid_partial" @checked(old('settlement_payment_status') === 'paid_partial')>
-                                                    <span>Bayar Sebagian</span>
-                                                </label>
-                                            </div>
-                                            @error('settlement_payment_status')
+                                            <label for="client_address" class="block text-sm font-medium text-gray-700">Alamat Klien</label>
+                                            <textarea name="client_address" id="client_address" rows="6" class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" :required="activeTab !== 'settlement'" :disabled="activeTab === 'settlement'">{{ old('client_address') }}</textarea>
+                                            @error('client_address')
                                                 <p class="mt-2 text-sm text-red-600">{{ $message }}</p>
                                             @enderror
                                         </div>
                                     </div>
                                 </div>
+
+                                <x-invoice.transaction-tabs
+                                    form-id="invoice-form"
+                                    :items="$oldItems"
+                                    :category-options="$categoryOptions"
+                                    :allowed-transactions="$allowedTransactions"
+                                    :default-transaction="$defaultTransaction"
+                                    variant="public"
+                                    down-payment-field-label="Rencana Down Payment"
+                                    down-payment-placeholder="Contoh: 5.000.000"
+                                    down-payment-help="Opsional. Nilai ini akan diusulkan sebagai nominal pembayaran awal ketika mencatat pembayaran."
+                                    :down-payment-required="false"
+                                    add-item-button-label="+ Tambah Item"
+                                    total-label="Total Invoice"
+                                    :down-payment-value="old('down_payment_due')"
+                                    :settlement-invoice-number="old('settlement_invoice_number')"
+                                    :settlement-remaining-balance="old('settlement_remaining_balance')"
+                                    :settlement-paid-amount="old('settlement_paid_amount')"
+                                    :settlement-payment-status="old('settlement_payment_status')"
+                                />
 
                                 <div class="flex justify-end">
                                     <button type="submit" class="inline-flex items-center justify-center rounded-xl bg-green-600 px-6 py-3 text-base font-semibold text-white shadow-lg hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2">
@@ -303,146 +194,5 @@
         </div>
     </div>
 
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const invoiceForm = document.getElementById('invoice-form');
-
-            if (!invoiceForm) {
-                return;
-            }
-
-            const categoryOptions = JSON.parse(invoiceForm.dataset.categoryOptions || '[]');
-            let itemIndex = invoiceForm.querySelectorAll('#invoice-items .invoice-item').length;
-            const invoiceItemsContainer = document.getElementById('invoice-items');
-            const totalAmountElement = document.getElementById('total-amount');
-            const addItemButton = document.getElementById('add-item');
-            const transactionTypeInput = document.getElementById('transaction_type');
-
-            function formatPrice(input) {
-                const raw = (input.value || '').replace(/\D/g, '');
-                input.dataset.rawValue = raw;
-                input.value = raw ? raw.replace(/\B(?=(\d{3})+(?!\d))/g, '.') : '';
-            }
-
-            function updateTotal() {
-                if (!invoiceItemsContainer || !totalAmountElement) {
-                    return;
-                }
-
-                let total = 0;
-                invoiceItemsContainer.querySelectorAll('.invoice-item').forEach((item) => {
-                    const quantity = parseInt(item.querySelector('.quantity')?.value || '0', 10) || 0;
-                    const price = parseInt(item.querySelector('.price-input')?.dataset.rawValue || '0', 10) || 0;
-                    total += quantity * price;
-                });
-
-                totalAmountElement.textContent = new Intl.NumberFormat('id-ID', {
-                    style: 'currency',
-                    currency: 'IDR',
-                }).format(total || 0);
-            }
-
-            function applyTransactionScope(transactionType) {
-                const scope = transactionType || 'down_payment';
-
-                if (addItemButton) {
-                    const isSettlement = scope === 'settlement';
-                    addItemButton.disabled = isSettlement;
-                    addItemButton.classList.toggle('opacity-50', isSettlement);
-                    addItemButton.classList.toggle('cursor-not-allowed', isSettlement);
-                }
-
-                if (invoiceItemsContainer) {
-                    invoiceItemsContainer.querySelectorAll('.category-select, .quantity, .price-input, .description').forEach((element) => {
-                        element.disabled = scope === 'settlement';
-                    });
-                }
-            }
-
-            document.querySelectorAll('.price-input').forEach((input) => {
-                formatPrice(input);
-                input.addEventListener('input', () => {
-                    formatPrice(input);
-                    updateTotal();
-                });
-                input.addEventListener('blur', () => formatPrice(input));
-            });
-
-            document.querySelectorAll('.quantity').forEach((input) => {
-                input.addEventListener('input', updateTotal);
-            });
-
-            if (addItemButton && invoiceItemsContainer) {
-                addItemButton.addEventListener('click', () => {
-                    const template = document.createElement('template');
-                    template.innerHTML = `
-                        <div class="grid grid-cols-12 gap-4 invoice-item bg-gray-50 p-4 rounded-xl">
-                            <div class="col-span-12 md:col-span-4">
-                                <textarea name="items[${itemIndex}][description]" rows="3" class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 description" placeholder="Deskripsi" required></textarea>
-                            </div>
-                            <div class="col-span-12 md:col-span-3">
-                                <select name="items[${itemIndex}][category_id]" class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 category-select" required>
-                                    ${['<option value="">Pilih kategori pemasukan</option>'].concat(categoryOptions.map((option) => `<option value="${option.id}">${option.name}</option>`)).join('')}
-                                </select>
-                            </div>
-                            <div class="col-span-6 md:col-span-2">
-                                <input type="number" name="items[${itemIndex}][quantity]" class="quantity mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" value="1" min="1" required>
-                            </div>
-                            <div class="col-span-6 md:col-span-2">
-                                <input type="text" name="items[${itemIndex}][price]" class="price-input mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder="Harga" required>
-                            </div>
-                            <div class="col-span-12 md:col-span-1 flex items-end justify-end">
-                                <button type="button" class="remove-item text-sm font-semibold text-red-600 hover:text-red-700">Hapus</button>
-                            </div>
-                        </div>
-                    `.trim();
-
-                    const element = template.content.firstChild;
-                    invoiceItemsContainer.appendChild(element);
-
-                    element.querySelectorAll('.price-input').forEach((input) => {
-                        formatPrice(input);
-                        input.addEventListener('input', () => {
-                            formatPrice(input);
-                            updateTotal();
-                        });
-                        input.addEventListener('blur', () => formatPrice(input));
-                    });
-
-                    element.querySelectorAll('.quantity').forEach((input) => {
-                        input.addEventListener('input', updateTotal);
-                    });
-
-                    itemIndex++;
-                    updateTotal();
-                });
-            }
-
-            if (invoiceItemsContainer) {
-                invoiceItemsContainer.addEventListener('click', (event) => {
-                    if (event.target.classList.contains('remove-item')) {
-                        const item = event.target.closest('.invoice-item');
-                        if (item) {
-                            item.remove();
-                            updateTotal();
-                        }
-                    }
-                });
-            }
-
-            invoiceForm.addEventListener('submit', () => {
-                document.querySelectorAll('.price-input').forEach((input) => {
-                    input.value = input.dataset.rawValue || '';
-                });
-            });
-
-            window.addEventListener('transaction-tab-changed', (event) => {
-                applyTransactionScope(event.detail);
-            });
-
-            applyTransactionScope(transactionTypeInput?.value || invoiceForm.dataset.defaultTab || 'down_payment');
-            updateTotal();
-        });
-    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extract a reusable transaction tabs component and apply it to the internal and public invoice creation forms
- branch invoice creation logic to handle settlement invoices that copy reference data and initialize payment status
- update the PDF layout to show transaction type, settlement context, and consistent payment details

## Testing
- `php artisan test` *(fails: missing vendor directory in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68df525d146c8331ab8a185ef0b1d6d5