### PR TITLE
Add comprehensive feature coverage tests

### DIFF
--- a/tests/Feature/AdminActivityLogControllerTest.php
+++ b/tests/Feature/AdminActivityLogControllerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\Role;
+use App\Models\ActivityLog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminActivityLogControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_view_activity_logs(): void
+    {
+        $admin = User::factory()->create(['role' => Role::ADMIN]);
+        $user = User::factory()->create();
+
+        $log = ActivityLog::create([
+            'user_id' => $user->id,
+            'description' => 'Membuka halaman laporan',
+            'method' => 'GET',
+            'url' => '/reports',
+            'ip_address' => '127.0.0.1',
+        ]);
+
+        $response = $this->actingAs($admin)->get(route('admin.activity-logs.index'));
+
+        $response->assertOk();
+        $response->assertViewIs('admin.activity_logs.index');
+        $response->assertViewHas('logs', function ($paginator) use ($log) {
+            return $paginator->contains(fn ($item) => $item->id === $log->id);
+        });
+    }
+
+    public function test_non_admin_cannot_access_activity_logs(): void
+    {
+        $user = User::factory()->create(['role' => Role::STAFF]);
+
+        $response = $this->actingAs($user)->get(route('admin.activity-logs.index'));
+
+        $response->assertForbidden();
+    }
+}

--- a/tests/Feature/AdminDeletionApprovalTest.php
+++ b/tests/Feature/AdminDeletionApprovalTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\Role;
+use App\Models\Category;
+use App\Models\Setting;
+use App\Models\Transaction;
+use App\Models\TransactionDeletionRequest;
+use App\Models\User;
+use App\Notifications\TransactionApproved;
+use App\Notifications\TransactionRejected;
+use App\Services\TransactionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class AdminDeletionApprovalTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_view_pending_deletion_requests(): void
+    {
+        $admin = User::factory()->create(['role' => Role::ADMIN]);
+        $requester = User::factory()->create();
+        $otherRequester = User::factory()->create();
+        $category = Category::factory()->create(['type' => 'pengeluaran']);
+
+        $transaction = Transaction::factory()->create([
+            'user_id' => $requester->id,
+            'category_id' => $category->id,
+        ]);
+
+        $otherTransaction = Transaction::factory()->create([
+            'user_id' => $otherRequester->id,
+            'category_id' => $category->id,
+        ]);
+
+        $pending = TransactionDeletionRequest::create([
+            'transaction_id' => $transaction->id,
+            'requested_by' => $requester->id,
+            'status' => 'pending',
+        ]);
+
+        TransactionDeletionRequest::create([
+            'transaction_id' => $otherTransaction->id,
+            'requested_by' => $otherRequester->id,
+            'status' => 'approved',
+        ]);
+
+        $response = $this->actingAs($admin)->get(route('admin.deletion-requests.index'));
+
+        $response->assertOk();
+        $response->assertViewIs('admin.deletion_requests.index');
+        $response->assertViewHas('requests', function ($collection) use ($pending) {
+            return $collection->contains(fn ($item) => $item->id === $pending->id)
+                && $collection->every(fn ($item) => $item->status === 'pending');
+        });
+    }
+
+    public function test_admin_can_approve_deletion_request(): void
+    {
+        Notification::fake();
+
+        $admin = User::factory()->create(['role' => Role::ADMIN]);
+        $requester = User::factory()->create();
+        $category = Category::factory()->create(['type' => 'pengeluaran']);
+
+        $transaction = Transaction::factory()->create([
+            'user_id' => $requester->id,
+            'category_id' => $category->id,
+            'amount' => 75000,
+        ]);
+
+        $deletionRequest = TransactionDeletionRequest::create([
+            'transaction_id' => $transaction->id,
+            'requested_by' => $requester->id,
+            'status' => 'pending',
+        ]);
+
+        Cache::forget('setting:notify_transaction_approved');
+        Setting::query()->updateOrCreate([
+            'key' => 'notify_transaction_approved',
+        ], [
+            'value' => true,
+        ]);
+
+        $serviceMock = \Mockery::mock(TransactionService::class);
+        $serviceMock->shouldReceive('clearSummaryCacheForUser')->once();
+        $this->app->instance(TransactionService::class, $serviceMock);
+
+        $response = $this->actingAs($admin)->post(route('admin.deletion-requests.approve', $deletionRequest));
+
+        $response->assertRedirect(route('admin.deletion-requests.index'));
+        $response->assertSessionHas('success', 'Permintaan penghapusan disetujui.');
+
+        $this->assertNull(Transaction::find($transaction->id));
+
+        $deletionRequest->refresh();
+        $this->assertSame('approved', $deletionRequest->status);
+        $this->assertSame($admin->id, $deletionRequest->approved_by);
+        $this->assertNotNull($deletionRequest->approved_at);
+
+        Notification::assertSentTo($requester, TransactionApproved::class);
+    }
+
+    public function test_admin_can_reject_deletion_request_with_reason(): void
+    {
+        Notification::fake();
+
+        $admin = User::factory()->create(['role' => Role::ADMIN]);
+        $requester = User::factory()->create();
+        $category = Category::factory()->create(['type' => 'pengeluaran']);
+
+        $transaction = Transaction::factory()->create([
+            'user_id' => $requester->id,
+            'category_id' => $category->id,
+        ]);
+
+        $deletionRequest = TransactionDeletionRequest::create([
+            'transaction_id' => $transaction->id,
+            'requested_by' => $requester->id,
+            'status' => 'pending',
+        ]);
+
+        $serviceMock = \Mockery::mock(TransactionService::class);
+        $serviceMock->shouldReceive('clearSummaryCacheForUser')->never();
+        $this->app->instance(TransactionService::class, $serviceMock);
+
+        $response = $this->actingAs($admin)->post(route('admin.deletion-requests.reject', $deletionRequest), [
+            'reason' => 'Data masih diperlukan',
+        ]);
+
+        $response->assertRedirect(route('admin.deletion-requests.index'));
+        $response->assertSessionHas('success', 'Permintaan penghapusan ditolak.');
+
+        $deletionRequest->refresh();
+        $this->assertSame('rejected', $deletionRequest->status);
+        $this->assertSame('Data masih diperlukan', $deletionRequest->reason);
+        $this->assertSame($admin->id, $deletionRequest->approved_by);
+        $this->assertNotNull($deletionRequest->approved_at);
+
+        Notification::assertSentTo($requester, TransactionRejected::class);
+    }
+}

--- a/tests/Feature/CustomerServiceTest.php
+++ b/tests/Feature/CustomerServiceTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\CustomerService;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CustomerServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_page_lists_customer_services(): void
+    {
+        $user = User::factory()->create();
+        $first = CustomerService::create([
+            'name' => 'Rina',
+            'email' => 'rina@example.com',
+            'phone' => '081234567890',
+        ]);
+        CustomerService::create([
+            'name' => 'Budi',
+            'email' => 'budi@example.com',
+            'phone' => '081111111111',
+        ]);
+
+        $response = $this->actingAs($user)->get(route('customer-services.create'));
+
+        $response->assertOk();
+        $response->assertViewIs('customer-services.create');
+        $response->assertViewHas('customerServices', function ($paginator) use ($first) {
+            return $paginator->contains($first);
+        });
+    }
+
+    public function test_store_validates_and_creates_customer_service(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('customer-services.store'), [
+            'name' => 'Tim Dukungan',
+            'email' => 'support@example.com',
+            'phone' => '081234567890',
+        ]);
+
+        $response->assertRedirect(route('customer-services.create'));
+        $response->assertSessionHas('status', 'Customer service berhasil ditambahkan.');
+
+        $this->assertDatabaseHas('customer_services', [
+            'name' => 'Tim Dukungan',
+            'email' => 'support@example.com',
+            'phone' => '081234567890',
+        ]);
+    }
+
+    public function test_store_requires_name(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('customer-services.store'), [
+            'name' => '',
+            'email' => 'invalid@example.com',
+        ]);
+
+        $response->assertSessionHasErrors('name');
+        $this->assertDatabaseCount('customer_services', 0);
+    }
+}

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Category;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Services\TransactionService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class DashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dashboard_displays_summary_and_financial_overview(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2024-05-15 12:00:00'));
+
+        $summary = [
+            'totalPemasukan' => 300000,
+            'totalPengeluaran' => 120000,
+            'saldo' => 180000,
+        ];
+
+        $this->app->bind(TransactionService::class, function () use ($summary) {
+            return new class($summary) extends TransactionService {
+                public function __construct(private array $summary)
+                {
+                }
+
+                public function getAllSummary(?Request $request = null): array
+                {
+                    return $this->summary;
+                }
+            };
+        });
+
+        $user = User::factory()->create();
+
+        $incomeCategory = Category::factory()->create(['type' => 'pemasukan']);
+        $expenseCategory = Category::factory()->create(['type' => 'pengeluaran']);
+
+        Transaction::factory()->create([
+            'category_id' => $incomeCategory->id,
+            'user_id' => $user->id,
+            'amount' => 150000,
+            'date' => Carbon::now()->startOfMonth()->addDays(2),
+        ]);
+
+        Transaction::factory()->create([
+            'category_id' => $expenseCategory->id,
+            'user_id' => $user->id,
+            'amount' => 50000,
+            'date' => Carbon::now()->startOfMonth()->addDays(4),
+        ]);
+
+        Transaction::factory()->create([
+            'category_id' => $incomeCategory->id,
+            'user_id' => $user->id,
+            'amount' => 100000,
+            'date' => Carbon::now()->subMonth()->startOfMonth()->addDays(3),
+        ]);
+
+        Transaction::factory()->create([
+            'category_id' => $expenseCategory->id,
+            'user_id' => $user->id,
+            'amount' => 20000,
+            'date' => Carbon::now()->subMonth()->startOfMonth()->addDays(5),
+        ]);
+
+        $response = $this->actingAs($user)->get(route('dashboard'));
+
+        $response->assertOk();
+        $response->assertViewIs('dashboard');
+        $response->assertViewHas('summary', $summary);
+        $response->assertViewHas('financial_overview', function (array $overview) {
+            $this->assertSame(150000, $overview['pemasukan']);
+            $this->assertSame(50000, $overview['pengeluaran']);
+            $this->assertSame(100000, $overview['net']);
+            $this->assertEqualsWithDelta(25.0, $overview['percent_change'], 0.001);
+
+            return true;
+        });
+        $response->assertViewHas('selected_month', '2024-05');
+        $response->assertViewHas('recent_transactions', function ($transactions) {
+            $this->assertCount(4, $transactions);
+
+            return $transactions->first()->date->greaterThanOrEqualTo($transactions->last()->date);
+        });
+
+        Carbon::setTestNow();
+    }
+}

--- a/tests/Feature/InvoicePortalPassphraseTest.php
+++ b/tests/Feature/InvoicePortalPassphraseTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\InvoicePortalPassphraseAccessType;
+use App\Enums\Role;
+use App\Models\InvoicePortalPassphrase;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class InvoicePortalPassphraseTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_view_passphrase_index(): void
+    {
+        $admin = User::factory()->create(['role' => Role::ADMIN]);
+        $creator = User::factory()->create();
+
+        $passphrase = new InvoicePortalPassphrase([
+            'public_id' => (string) Str::uuid(),
+            'access_type' => InvoicePortalPassphraseAccessType::CUSTOMER_SERVICE,
+            'label' => 'Tim A',
+            'is_active' => true,
+            'created_by' => $creator->id,
+        ]);
+        $passphrase->setPassphrase('PassphraseRahasia12');
+        $passphrase->save();
+
+        $response = $this->actingAs($admin)->get(route('invoice-portal.passphrases.index'));
+
+        $response->assertOk();
+        $response->assertViewIs('invoice-portal.passphrases.index');
+        $response->assertViewHas('passphrases', function ($collection) use ($passphrase) {
+            return $collection->contains(fn ($item) => $item->id === $passphrase->id);
+        });
+        $response->assertViewHas('accessTypes', InvoicePortalPassphraseAccessType::cases());
+    }
+
+    public function test_admin_can_store_passphrase_with_random_generation(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2024-01-01 00:00:00'));
+
+        $admin = User::factory()->create(['role' => Role::ADMIN]);
+
+        $response = $this->actingAs($admin)->post(route('invoice-portal.passphrases.store'), [
+            'access_type' => InvoicePortalPassphraseAccessType::CUSTOMER_SERVICE->value,
+            'label' => 'Tim Sales',
+            'expires_at' => Carbon::now()->addDays(7)->toDateTimeString(),
+            'passphrase' => '',
+        ]);
+
+        $response->assertRedirect(route('invoice-portal.passphrases.index'));
+        $response->assertSessionHas('status', 'Passphrase portal invoice baru berhasil dibuat.');
+        $response->assertSessionHas('passphrase_plain', function (array $data) {
+            return strlen($data['value']) === 16 && $data['label'] === 'Tim Sales (Customer Service)';
+        });
+
+        $passphrase = InvoicePortalPassphrase::where('label', 'Tim Sales')->first();
+        $this->assertNotNull($passphrase);
+        $this->assertTrue($passphrase->is_active);
+        $this->assertDatabaseHas('invoice_portal_passphrases', [
+            'id' => $passphrase->id,
+            'access_type' => InvoicePortalPassphraseAccessType::CUSTOMER_SERVICE->value,
+        ]);
+        $this->assertDatabaseHas('invoice_portal_passphrase_logs', [
+            'invoice_portal_passphrase_id' => $passphrase->id,
+            'action' => 'generated',
+        ]);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_admin_can_rotate_active_passphrase(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2024-02-01 00:00:00'));
+
+        $admin = User::factory()->create(['role' => Role::ADMIN]);
+        $creator = User::factory()->create();
+
+        $passphrase = new InvoicePortalPassphrase([
+            'public_id' => (string) Str::uuid(),
+            'access_type' => InvoicePortalPassphraseAccessType::CUSTOMER_SERVICE,
+            'label' => 'Tim Lama',
+            'is_active' => true,
+            'created_by' => $creator->id,
+        ]);
+        $passphrase->setPassphrase('PassphraseLama123');
+        $passphrase->save();
+
+        $response = $this->actingAs($admin)->post(route('invoice-portal.passphrases.rotate', $passphrase), [
+            'label' => 'Tim Baru',
+            'passphrase' => 'PassphraseBaru12',
+            'expires_at' => Carbon::now()->addDays(10)->toDateTimeString(),
+        ]);
+
+        $response->assertRedirect(route('invoice-portal.passphrases.index'));
+        $response->assertSessionHas('status', 'Passphrase berhasil diperbarui. Pastikan segera dibagikan ke pihak terkait.');
+        $response->assertSessionHas('passphrase_plain', [
+            'value' => 'PassphraseBaru12',
+            'label' => 'Tim Baru (Customer Service)',
+        ]);
+
+        $updated = $passphrase->fresh();
+        $this->assertSame('Tim Baru', $updated->label);
+        $this->assertTrue($updated->is_active);
+        $this->assertTrue($updated->expires_at->greaterThan(Carbon::now()));
+
+        $this->assertDatabaseHas('invoice_portal_passphrase_logs', [
+            'invoice_portal_passphrase_id' => $passphrase->id,
+            'action' => 'rotated',
+        ]);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_admin_can_deactivate_passphrase(): void
+    {
+        $admin = User::factory()->create(['role' => Role::ADMIN]);
+        $creator = User::factory()->create();
+
+        $passphrase = new InvoicePortalPassphrase([
+            'public_id' => (string) Str::uuid(),
+            'access_type' => InvoicePortalPassphraseAccessType::ADMIN_PELUNASAN,
+            'label' => 'Tim Pelunasan',
+            'is_active' => true,
+            'created_by' => $creator->id,
+        ]);
+        $passphrase->setPassphrase('RahasiaPelunasan12');
+        $passphrase->save();
+
+        $response = $this->actingAs($admin)->delete(route('invoice-portal.passphrases.deactivate', $passphrase));
+
+        $response->assertRedirect();
+        $response->assertSessionHas('status', 'Passphrase berhasil dinonaktifkan.');
+
+        $passphrase->refresh();
+        $this->assertFalse($passphrase->is_active);
+        $this->assertNotNull($passphrase->deactivated_at);
+        $this->assertSame($admin->id, $passphrase->deactivated_by);
+        $this->assertDatabaseHas('invoice_portal_passphrases', [
+            'id' => $passphrase->id,
+            'is_active' => false,
+        ]);
+
+        $this->assertDatabaseHas('invoice_portal_passphrase_logs', [
+            'invoice_portal_passphrase_id' => $passphrase->id,
+            'action' => 'deactivated',
+        ]);
+    }
+
+    public function test_deactivate_returns_message_when_passphrase_already_inactive(): void
+    {
+        $admin = User::factory()->create(['role' => Role::ADMIN]);
+        $creator = User::factory()->create();
+
+        $passphrase = new InvoicePortalPassphrase([
+            'public_id' => (string) Str::uuid(),
+            'access_type' => InvoicePortalPassphraseAccessType::CUSTOMER_SERVICE,
+            'label' => 'Tim Nonaktif',
+            'is_active' => false,
+            'created_by' => $creator->id,
+        ]);
+        $passphrase->setPassphrase('PassphraseTidakAktif12');
+        $passphrase->save();
+
+        $response = $this->actingAs($admin)->delete(route('invoice-portal.passphrases.deactivate', $passphrase));
+
+        $response->assertRedirect();
+        $response->assertSessionHas('status', 'Passphrase sudah tidak aktif.');
+    }
+}

--- a/tests/Feature/InvoicePortalPassphraseVerificationTest.php
+++ b/tests/Feature/InvoicePortalPassphraseVerificationTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\InvoicePortalPassphraseAccessType;
+use App\Models\InvoicePortalPassphrase;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class InvoicePortalPassphraseVerificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_passphrase_verification_stores_session_and_logs_usage(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2024-03-10 08:00:00'));
+
+        $creator = User::factory()->create();
+        $passphrase = new InvoicePortalPassphrase([
+            'public_id' => (string) Str::uuid(),
+            'access_type' => InvoicePortalPassphraseAccessType::CUSTOMER_SERVICE,
+            'label' => 'Tim Customer Service',
+            'is_active' => true,
+            'created_by' => $creator->id,
+        ]);
+        $passphrase->setPassphrase('ValidPassphrase12');
+        $passphrase->save();
+
+        $response = $this->post(route('invoices.public.passphrase.verify'), [
+            'passphrase' => 'ValidPassphrase12',
+        ]);
+
+        $response->assertRedirect(route('invoices.public.create'));
+        $response->assertSessionHas('passphrase_verified');
+
+        $sessionData = session('invoice_portal_passphrase');
+        $this->assertSame($passphrase->id, $sessionData['id']);
+        $this->assertSame($passphrase->access_type->value, $sessionData['access_type']);
+        $this->assertSame($passphrase->displayLabel(), $sessionData['display_label']);
+
+        $passphrase->refresh();
+        $this->assertSame(1, $passphrase->usage_count);
+        $this->assertNotNull($passphrase->last_used_at);
+
+        $this->assertDatabaseHas('invoice_portal_passphrase_logs', [
+            'invoice_portal_passphrase_id' => $passphrase->id,
+            'action' => 'verified',
+        ]);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_passphrase_verification_fails_for_invalid_passphrase(): void
+    {
+        $creator = User::factory()->create();
+        $passphrase = new InvoicePortalPassphrase([
+            'public_id' => (string) Str::uuid(),
+            'access_type' => InvoicePortalPassphraseAccessType::CUSTOMER_SERVICE,
+            'label' => 'Tim CS',
+            'is_active' => true,
+            'created_by' => $creator->id,
+        ]);
+        $passphrase->setPassphrase('ValidPassphrase12');
+        $passphrase->save();
+
+        $response = $this->from(route('invoices.public.create'))->post(route('invoices.public.passphrase.verify'), [
+            'passphrase' => 'SalahPassphrase',
+        ]);
+
+        $response->assertRedirect(route('invoices.public.create'));
+        $response->assertSessionHasErrors('passphrase', null, 'passphraseVerification');
+        $this->assertNull(session('invoice_portal_passphrase'));
+    }
+
+    public function test_passphrase_logout_clears_session(): void
+    {
+        $this->withSession([
+            'invoice_portal_passphrase' => [
+                'id' => 10,
+                'token' => 'encrypted-token',
+            ],
+        ]);
+
+        $response = $this->post(route('invoices.public.passphrase.logout'));
+
+        $response->assertRedirect(route('invoices.public.create'));
+        $response->assertSessionHas('status', 'Sesi passphrase telah diakhiri.');
+        $this->assertNull(session('invoice_portal_passphrase'));
+    }
+}

--- a/tests/Feature/UserDeletionRequestTest.php
+++ b/tests/Feature/UserDeletionRequestTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Category;
+use App\Models\Transaction;
+use App\Models\TransactionDeletionRequest;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserDeletionRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_view_their_deletion_requests(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $category = Category::factory()->create(['type' => 'pengeluaran']);
+
+        $transaction = Transaction::factory()->create([
+            'user_id' => $user->id,
+            'category_id' => $category->id,
+        ]);
+
+        $otherTransaction = Transaction::factory()->create([
+            'user_id' => $otherUser->id,
+            'category_id' => $category->id,
+        ]);
+
+        $ownRequest = TransactionDeletionRequest::create([
+            'transaction_id' => $transaction->id,
+            'requested_by' => $user->id,
+            'status' => 'pending',
+            'deletion_reason' => 'Duplikasi data',
+        ]);
+
+        $otherRequest = TransactionDeletionRequest::create([
+            'transaction_id' => $otherTransaction->id,
+            'requested_by' => $otherUser->id,
+            'status' => 'pending',
+            'deletion_reason' => 'Kesalahan input',
+        ]);
+
+        $response = $this->actingAs($user)->get(route('user-deletion-requests.index'));
+
+        $response->assertOk();
+        $response->assertViewIs('user_deletion_requests.index');
+        $response->assertViewHas('requests', function ($paginator) use ($ownRequest, $otherRequest) {
+            return $paginator->contains(fn ($item) => $item->id === $ownRequest->id)
+                && ! $paginator->contains(fn ($item) => $item->id === $otherRequest->id);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add feature tests for dashboard, customer service, and user deletion request experiences
- cover invoice portal passphrase management and public verification flows
- ensure admin activity log and deletion approval behaviour remain stable

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_b_68df7b72197c8331bc638320d52fed91