### PR TITLE
Remove unused customer service and settlement admin roles

### DIFF
--- a/app/Enums/Role.php
+++ b/app/Enums/Role.php
@@ -7,8 +7,6 @@ enum Role: string
     case ADMIN = 'admin';
     case ACCOUNTANT = 'accountant';
     case STAFF = 'staff';
-    case CUSTOMER_SERVICE = 'customer_service';
-    case SETTLEMENT_ADMIN = 'settlement_admin';
 
     public function label(): string
     {
@@ -16,8 +14,6 @@ enum Role: string
             self::ADMIN => 'Admin',
             self::ACCOUNTANT => 'Accountant',
             self::STAFF => 'Staff',
-            self::CUSTOMER_SERVICE => 'Customer Service',
-            self::SETTLEMENT_ADMIN => 'Admin Pelunasan',
         };
     }
 }

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -38,17 +38,17 @@ class InvoiceController extends Controller
         $tabPermissions = [
             'down-payment' => [
                 'label' => 'Down Payment',
-                'role' => Role::CUSTOMER_SERVICE,
+                'role' => null,
                 'allowed' => Gate::allows('viewDownPaymentTab', Invoice::class),
             ],
             'pay-in-full' => [
                 'label' => 'Bayar Lunas',
-                'role' => Role::CUSTOMER_SERVICE,
+                'role' => null,
                 'allowed' => Gate::allows('viewPayInFullTab', Invoice::class),
             ],
             'settlement' => [
                 'label' => 'Pelunasan',
-                'role' => Role::SETTLEMENT_ADMIN,
+                'role' => null,
                 'allowed' => Gate::allows('viewSettlementTab', Invoice::class),
             ],
         ];
@@ -57,8 +57,19 @@ class InvoiceController extends Controller
         foreach ($tabPermissions as $key => $config) {
             $role = $config['role'];
             $allowed = $config['allowed'];
-            $unlocked = $allowed && ($user->role === Role::ADMIN || $verifiedRoles->contains($role->value));
-            $requiresCode = $allowed && $user->role === $role && ! $verifiedRoles->contains($role->value);
+            $unlocked = $allowed;
+            $requiresCode = false;
+
+            if ($role instanceof Role) {
+                $unlocked = $allowed && (
+                    $user->role === Role::ADMIN
+                    || $verifiedRoles->contains($role->value)
+                );
+
+                $requiresCode = $allowed
+                    && $user->role === $role
+                    && ! $verifiedRoles->contains($role->value);
+            }
 
             $tabStates[$key] = [
                 'label' => $config['label'],

--- a/app/Policies/InvoicePolicy.php
+++ b/app/Policies/InvoicePolicy.php
@@ -41,21 +41,21 @@ class InvoicePolicy
     public function storePayment(User $user, Invoice $invoice): bool
     {
         return $user->id === $invoice->user_id
-            || in_array($user->role, [Role::ADMIN, Role::ACCOUNTANT, Role::CUSTOMER_SERVICE], true);
+            || in_array($user->role, [Role::ADMIN, Role::ACCOUNTANT], true);
     }
 
     public function viewDownPaymentTab(User $user): bool
     {
-        return in_array($user->role, [Role::ADMIN, Role::CUSTOMER_SERVICE], true);
+        return in_array($user->role, [Role::ADMIN, Role::ACCOUNTANT, Role::STAFF], true);
     }
 
     public function viewPayInFullTab(User $user): bool
     {
-        return in_array($user->role, [Role::ADMIN, Role::CUSTOMER_SERVICE], true);
+        return in_array($user->role, [Role::ADMIN, Role::ACCOUNTANT, Role::STAFF], true);
     }
 
     public function viewSettlementTab(User $user): bool
     {
-        return in_array($user->role, [Role::ADMIN, Role::SETTLEMENT_ADMIN], true);
+        return in_array($user->role, [Role::ADMIN, Role::ACCOUNTANT], true);
     }
 }

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
-            $table->enum('role', ['admin', 'accountant', 'staff', 'customer_service', 'settlement_admin'])->default('staff');
+            $table->enum('role', ['admin', 'accountant', 'staff'])->default('staff');
             $table->rememberToken();
             $table->timestamps();
         });

--- a/database/migrations/2025_09_10_000001_add_customer_service_id_to_invoices_table.php
+++ b/database/migrations/2025_09_10_000001_add_customer_service_id_to_invoices_table.php
@@ -28,8 +28,6 @@ return new class extends Migration
                     Role::ADMIN->value,
                     Role::ACCOUNTANT->value,
                     Role::STAFF->value,
-                    Role::CUSTOMER_SERVICE->value,
-                    Role::SETTLEMENT_ADMIN->value,
                 ])
                 ->get();
 

--- a/database/migrations/2025_09_20_000200_update_roles_enum.php
+++ b/database/migrations/2025_09_20_000200_update_roles_enum.php
@@ -14,7 +14,7 @@ return new class extends Migration
 
         DB::statement("
             ALTER TABLE users
-            MODIFY COLUMN role ENUM('admin','accountant','staff','customer_service','settlement_admin')
+            MODIFY COLUMN role ENUM('admin','accountant','staff')
             DEFAULT 'staff'
         ");
     }
@@ -27,7 +27,7 @@ return new class extends Migration
 
         DB::statement("
             ALTER TABLE users
-            MODIFY COLUMN role ENUM('admin','accountant','staff')
+            MODIFY COLUMN role ENUM('admin','accountant','staff','customer_service','settlement_admin')
             DEFAULT 'staff'
         ");
     }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Seeder;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use App\Enums\Role;
-use App\Models\AccessCode;
 
 class UserSeeder extends Seeder
 {
@@ -19,8 +18,6 @@ class UserSeeder extends Seeder
             'admin@vodeco.co.id',
             'staff@vodeco.co.id',
             'accountant@vodeco.co.id',
-            'cs@vodeco.co.id',
-            'pelunasan@vodeco.co.id',
         ])->delete();
 
         // Buat User Admin baru
@@ -45,36 +42,5 @@ class UserSeeder extends Seeder
             'role' => Role::ACCOUNTANT,
         ]);
 
-        $customerService = User::create([
-            'name' => 'Customer Service',
-            'email' => 'cs@vodeco.co.id',
-            'password' => Hash::make('masukaja'),
-            'role' => Role::CUSTOMER_SERVICE,
-        ]);
-
-        $settlementAdmin = User::create([
-            'name' => 'Admin Pelunasan',
-            'email' => 'pelunasan@vodeco.co.id',
-            'password' => Hash::make('masukaja'),
-            'role' => Role::SETTLEMENT_ADMIN,
-        ]);
-
-        $this->seedAccessCode($customerService, Role::CUSTOMER_SERVICE, '11111111-1111-4111-8111-111111111111', 'CS-ACCESS-001');
-        $this->seedAccessCode($settlementAdmin, Role::SETTLEMENT_ADMIN, '22222222-2222-4222-8222-222222222222', 'PELUNASAN-001');
-    }
-
-    private function seedAccessCode(User $user, Role $role, string $publicId, string $rawCode): void
-    {
-        AccessCode::where('public_id', $publicId)->delete();
-
-        AccessCode::create([
-            'public_id' => $publicId,
-            'user_id' => $user->id,
-            'role' => $role,
-            'code_hash' => Hash::make($rawCode),
-            'used_at' => null,
-            'used_by' => null,
-            'expires_at' => now()->addMonths(3),
-        ]);
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -56,7 +56,7 @@ Route::post('/access-codes/verify', [AccessCodeController::class, 'verify'])
     ->middleware('auth')
     ->name('access-codes.verify');
 
-Route::middleware(['auth', 'role:admin,accountant,staff,customer_service,settlement_admin'])->group(function () {
+Route::middleware(['auth', 'role:admin,accountant,staff'])->group(function () {
     // Dashboard
     Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
 

--- a/tests/Feature/AccessCodeTest.php
+++ b/tests/Feature/AccessCodeTest.php
@@ -4,10 +4,8 @@ namespace Tests\Feature;
 
 use App\Enums\Role;
 use App\Models\AccessCode;
-use App\Models\Invoice;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Tests\TestCase;
@@ -16,84 +14,52 @@ class AccessCodeTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_customer_service_requires_access_code_before_viewing_tabs(): void
+    public function test_staff_can_view_payment_tabs_without_access_code(): void
     {
-        $user = User::factory()->create(['role' => Role::CUSTOMER_SERVICE]);
-        Invoice::factory()->create(['user_id' => $user->id, 'down_payment_due' => 100000, 'down_payment' => 0]);
-
-        $publicId = (string) Str::uuid();
-        $rawCode = 'CS-UNIT-001';
-
-        AccessCode::create([
-            'public_id' => $publicId,
-            'user_id' => $user->id,
-            'role' => Role::CUSTOMER_SERVICE,
-            'code_hash' => Hash::make($rawCode),
-        ]);
-
+        $user = User::factory()->create(['role' => Role::STAFF]);
         $this->actingAs($user);
-
-        $this->get(route('invoices.index'))
-            ->assertOk()
-            ->assertDontSee('Down Payment');
-
-        $this->post(route('access-codes.verify'), ['code' => $publicId . ':' . $rawCode])
-            ->assertRedirect(route('invoices.index'));
 
         $response = $this->get(route('invoices.index'));
         $response->assertOk();
         $tabStates = $response->viewData('tabStates');
         $this->assertTrue($tabStates['down-payment']['unlocked']);
         $this->assertTrue($tabStates['pay-in-full']['unlocked']);
+        $this->assertFalse($tabStates['down-payment']['requires_code']);
+        $this->assertFalse($tabStates['pay-in-full']['requires_code']);
     }
 
-    public function test_settlement_admin_needs_access_code_for_pelunasan_tab(): void
+    public function test_accountant_can_view_settlement_tab_without_access_code(): void
     {
-        $user = User::factory()->create(['role' => Role::SETTLEMENT_ADMIN]);
-        Invoice::factory()->create(['user_id' => $user->id, 'status' => 'belum lunas']);
-
-        $publicId = (string) Str::uuid();
-        $rawCode = 'PELUNASAN-UNIT-1';
-
-        AccessCode::create([
-            'public_id' => $publicId,
-            'user_id' => $user->id,
-            'role' => Role::SETTLEMENT_ADMIN,
-            'code_hash' => Hash::make($rawCode),
-        ]);
-
+        $user = User::factory()->create(['role' => Role::ACCOUNTANT]);
         $this->actingAs($user);
 
         $response = $this->get(route('invoices.index'));
         $response->assertOk();
-        $this->assertFalse($response->viewData('tabStates')['settlement']['unlocked']);
-
-        $this->post(route('access-codes.verify'), ['code' => $publicId . ':' . $rawCode])
-            ->assertRedirect(route('invoices.index'));
-
-        $this->assertEquals(['settlement_admin'], session('verified_access_roles'));
-        $this->assertTrue(Gate::forUser($user)->allows('viewSettlementTab', Invoice::class));
-
-        $response = $this->get(route('invoices.index'));
-
-        $response->assertOk();
         $tabStates = $response->viewData('tabStates');
         $this->assertTrue($tabStates['settlement']['unlocked']);
+        $this->assertFalse($tabStates['settlement']['requires_code']);
         $this->assertSame('Pelunasan', $tabStates['settlement']['label']);
     }
 
-    public function test_admin_can_view_tabs_without_access_code(): void
+    public function test_accountant_can_verify_access_code(): void
     {
-        $admin = User::factory()->create(['role' => Role::ADMIN]);
-        Invoice::factory()->create(['user_id' => $admin->id, 'down_payment_due' => 50000, 'down_payment' => 0]);
+        $user = User::factory()->create(['role' => Role::ACCOUNTANT]);
+        $publicId = (string) Str::uuid();
+        $rawCode = 'ACCOUNTING-001';
 
-        $this->actingAs($admin);
+        $accessCode = AccessCode::create([
+            'public_id' => $publicId,
+            'user_id' => $user->id,
+            'role' => Role::ACCOUNTANT,
+            'code_hash' => Hash::make($rawCode),
+        ]);
 
-        $response = $this->get(route('invoices.index'));
-        $response->assertOk();
-        $tabStates = $response->viewData('tabStates');
-        $this->assertTrue($tabStates['down-payment']['unlocked']);
-        $this->assertTrue($tabStates['pay-in-full']['unlocked']);
-        $this->assertTrue($tabStates['settlement']['unlocked']);
+        $this->actingAs($user);
+
+        $this->post(route('access-codes.verify'), ['code' => $publicId . ':' . $rawCode])
+            ->assertRedirect(route('invoices.index'));
+
+        $this->assertNotNull($accessCode->fresh()->used_at);
+        $this->assertContains(Role::ACCOUNTANT->value, session('verified_access_roles'));
     }
 }


### PR DESCRIPTION
## Summary
- remove the customer service and settlement admin roles from the role enum, migrations, seed data, and route middleware
- adjust invoice tab access logic and policies so existing roles can view payment tabs without one-time codes
- refresh access code feature tests to cover the updated role behaviour

## Testing
- php artisan test *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_b_68df7fcf6b64833188e825952b0b7cc0