### PR TITLE
Allow privileged roles to view transaction proofs

### DIFF
--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -174,7 +174,15 @@ class TransactionController extends Controller
 
     public function showProof(Transaction $transaction)
     {
-        if (auth()->user()->id !== $transaction->user_id) {
+        $user = auth()->user();
+
+        if (!$user) {
+            abort(403, 'UNAUTHORIZED ACTION');
+        }
+
+        $isPrivilegedRole = in_array($user->role, [Role::ADMIN, Role::ACCOUNTANT], true);
+
+        if (!$isPrivilegedRole && $user->id !== $transaction->user_id) {
             abort(403, 'UNAUTHORIZED ACTION');
         }
 


### PR DESCRIPTION
## Summary
- allow admins and accountants to access stored transaction proofs without hitting authorization errors
- cover proof access rules for admin, accountant, and staff roles with feature tests

## Testing
- php artisan test --filter=TransactionTest

------
https://chatgpt.com/codex/tasks/task_b_68df8e4055b48331b1816719fcf09dde