### PR TITLE
Remove after column modifiers from transaction deletion request migration

### DIFF
--- a/database/migrations/2025_09_08_031556_create_transaction_deletion_requests_table.php
+++ b/database/migrations/2025_09_08_031556_create_transaction_deletion_requests_table.php
@@ -16,8 +16,8 @@ return new class extends Migration
             $table->foreignId('transaction_id');
             $table->foreignId('requested_by')->constrained('users')->cascadeOnDelete();
             $table->string('status')->default('pending');
-            $table->text('reason')->nullable()->after('status');
-            $table->text('deletion_reason')->nullable()->after('reason');
+            $table->text('reason')->nullable();
+            $table->text('deletion_reason')->nullable();
             $table->foreignId('approved_by')->nullable()->constrained('users')->nullOnDelete();
             $table->timestamp('approved_at')->nullable();
             $table->timestamps();


### PR DESCRIPTION
## Summary
- update the transaction deletion requests migration to rely on column declaration order for the reason fields

## Testing
- php artisan migrate:fresh --seed --force

------
https://chatgpt.com/codex/tasks/task_b_68e07d01cd148329af276bbea3a802b0