### PR TITLE
Fix long foreign key name for passphrase logs

### DIFF
--- a/database/migrations/2025_10_01_000000_create_invoice_portal_passphrases_table.php
+++ b/database/migrations/2025_10_01_000000_create_invoice_portal_passphrases_table.php
@@ -28,8 +28,10 @@ return new class extends Migration
 
         Schema::create('invoice_portal_passphrase_logs', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('invoice_portal_passphrase_id')
-                ->constrained('invoice_portal_passphrases')
+            $table->foreignId('invoice_portal_passphrase_id');
+            $table->foreign('invoice_portal_passphrase_id', 'passphrase_log_passphrase_fk')
+                ->references('id')
+                ->on('invoice_portal_passphrases')
                 ->cascadeOnDelete();
             $table->string('action');
             $table->string('ip_address', 45)->nullable();


### PR DESCRIPTION
## Summary
- define the invoice portal passphrase log foreign key with a shorter custom name to avoid MySQL identifier length limits

## Testing
- php artisan migrate:fresh --seed *(fails: missing vendor directory in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e08a08112483298e438488685f2c4d