### PR TITLE
Mark full payment invoices as paid during creation

### DIFF
--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -605,8 +605,12 @@ class InvoiceController extends Controller
 
             $status = match ($transactionType) {
                 'down_payment' => 'belum lunas',
+                'full_payment' => 'lunas',
                 default => 'belum bayar',
             };
+
+            $downPayment = $transactionType === 'full_payment' ? $total : 0;
+            $paymentDate = $transactionType === 'full_payment' ? now() : null;
 
             $invoice = Invoice::create([
                 'user_id' => $ownerId ?? auth()->id(),
@@ -623,9 +627,9 @@ class InvoiceController extends Controller
                 'total' => $total,
                 'type' => Invoice::TYPE_STANDARD,
                 'reference_invoice_id' => null,
-                'down_payment' => 0,
+                'down_payment' => $downPayment,
                 'down_payment_due' => $downPaymentDue,
-                'payment_date' => null,
+                'payment_date' => $paymentDate,
             ]);
 
             foreach ($items as $item) {


### PR DESCRIPTION
## Summary
- ensure invoices created with the Bayar Lunas transaction type record a paid status, full down payment, and payment date
- add a feature test covering full payment invoice creation to guard against regressions

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_b_68e0c1d8663083298ebdb15b8a28432f