### PR TITLE
Fix DOMPDF watermark rendering in financial report and invoice PDFs

### DIFF
--- a/resources/views/exports/financial_report_pdf.blade.php
+++ b/resources/views/exports/financial_report_pdf.blade.php
@@ -19,28 +19,38 @@
         }
 
         @if ($watermarkData)
-        body::before {
-            content: "";
+        .watermark {
             position: fixed;
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
             width: 100%;
             height: 100%;
-            background-image: url('data:image/{{ $watermarkExtension }};base64,{{ $watermarkData }}');
-            background-position: center;
-            background-repeat: no-repeat;
-            background-size: contain;
             opacity: 0.08;
+            z-index: 0;
+            pointer-events: none;
+        }
+
+        .watermark img {
+            width: 100%;
+            height: 100%;
+            object-fit: contain;
         }
         @endif
 
         .report-wrapper {
             width: 100%;
+            position: relative;
+            z-index: 1;
         }
     </style>
 </head>
 <body>
+    @if ($watermarkData)
+    <div class="watermark">
+        <img src="data:image/{{ $watermarkExtension }};base64,{{ $watermarkData }}" alt="Watermark">
+    </div>
+    @endif
     <div class="report-wrapper">
         <h1>Laporan Keuangan</h1>
         <p class="report-period">Periode: {{ \Carbon\Carbon::parse($period['start'])->isoFormat('D MMMM YYYY') }} - {{ \Carbon\Carbon::parse($period['end'])->isoFormat('D MMMM YYYY') }}</p>

--- a/resources/views/invoices/pdf.blade.php
+++ b/resources/views/invoices/pdf.blade.php
@@ -77,29 +77,42 @@
             position: relative;
         }
         @if ($watermarkData)
-        body::before {
-            content: "";
+        .watermark {
             position: fixed;
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
             width: 100%;
             height: 100%;
-            background-image: url('data:image/{{ $watermarkMime }};base64,{{ $watermarkData }}');
-            background-position: center;
-            background-repeat: no-repeat;
-            background-size: contain;
             opacity: 0.08;
+            z-index: 0;
+            pointer-events: none;
+        }
+
+        .watermark img {
+            width: 100%;
+            height: 100%;
+            object-fit: contain;
+        }
+
+        .pdf-content {
+            position: relative;
+            z-index: 1;
         }
         @endif
     </style>
 </head>
 
 <body class="text-sm">
+    @if ($watermarkData)
+    <div class="watermark">
+        <img src="data:image/{{ $watermarkMime }};base64,{{ $watermarkData }}" alt="Watermark">
+    </div>
+    @endif
     <div style="position: absolute; top: 0; right: 0;">
         <img src="data:image/png;base64,{{ $headerBgData }}" style="width: 200px; height: auto;">
     </div>
-    <div class="mx-auto max-w-[210mm] bg-white px-10 py-8">
+    <div class="mx-auto max-w-[210mm] bg-white px-10 py-8 pdf-content">
         <!-- Header -->
         <table style="width: 100%;margin-top: 40px;">
             <tr>


### PR DESCRIPTION
## Summary
- replace the pseudo-element watermark in the financial report PDF with a fixed-position container
- render the invoice watermark via an HTML element and keep page content layered above it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e32b042694832999681851541ae8c3