### PR TITLE
Fix modal padding styling

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -66,7 +66,9 @@ $maxWidth = [
     <div
         x-show="show"
         x-on:click.stop
-        class="mb-6 bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidth }} sm:mx-auto"
+        {{ $attributes->merge([
+            'class' => "mb-6 bg-white rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {$maxWidth} sm:mx-auto"
+        ]) }}
         x-transition:enter="ease-out duration-300"
         x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
         x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"

--- a/resources/views/invoice-portal/passphrases/index.blade.php
+++ b/resources/views/invoice-portal/passphrases/index.blade.php
@@ -163,18 +163,18 @@
                                         </td>
                                     </tr>
                                     <x-modal name="edit-passphrase-{{ $passphrase->id }}" :show="$isEditingThis || $errors->has('passphrase_'.$passphrase->id)" focusable class="p-6 sm:p-8 max-w-lg">
-                                        <form action="{{ route('invoice-portal.passphrases.rotate', $passphrase) }}" method="POST" class="space-y-6 p-6 sm:p-8">
+                                        <form action="{{ route('invoice-portal.passphrases.rotate', $passphrase) }}" method="POST" class="space-y-6">
                                             @csrf
                                             <input type="hidden" name="editing_passphrase" value="{{ $passphrase->id }}">
 
-                                            <div>
-                                                <h4 class="text-lg font-semibold text-gray-900 dark:text-white mx-6">Edit Passphrase</h4>
-                                                <p class="mt-1 text-sm text-gray-600 dark:text-gray-300 mx-6">Perbarui informasi passphrase atau putar nilai passphrase baru sesuai kebutuhan.</p>
+                                            <div class="space-y-1">
+                                                <h4 class="text-lg font-semibold text-gray-900 dark:text-white">Edit Passphrase</h4>
+                                                <p class="text-sm text-gray-600 dark:text-gray-300">Perbarui informasi passphrase atau putar nilai passphrase baru sesuai kebutuhan.</p>
                                             </div>
 
                                             @if ($isEditingThis && $errors->hasBag('rotatePassphrase'))
-                                                <div class=" mx-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
-                                                    <ul class="mx-6 list-disc space-y-1 pl-5">
+                                                <div class="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+                                                    <ul class="list-disc space-y-1 pl-5">
                                                         @foreach ($errors->getBag('rotatePassphrase')->all() as $message)
                                                             <li>{{ $message }}</li>
                                                         @endforeach


### PR DESCRIPTION
## Summary
- allow the shared modal component to merge custom utility classes for layout control
- tidy the Edit Passphrase modal content spacing for a more consistent layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e3400d8a648329aacfafd64b4d4e3f