### PR TITLE
Align invoice payment transactions with invoice metadata

### DIFF
--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -168,7 +168,7 @@ class DebtController extends Controller
                         'category_id' => $debt->category_id,
                         'date' => $validated['payment_date'] ?? now(),
                         'amount' => $debt->amount,
-                        'description' => 'Pelunasan: ' . $debt->description,
+                        'description' => $debt->description,
                         'user_id' => $request->user()->id, // Keamanan: Pastikan transaksi memiliki pemilik
                     ]);
 

--- a/app/Services/InvoiceSettlementService.php
+++ b/app/Services/InvoiceSettlementService.php
@@ -112,7 +112,7 @@ class InvoiceSettlementService
                         'category_id' => $categoryId,
                         'user_id' => $invoice->user_id,
                         'amount' => $remainingBalance,
-                        'description' => 'Pelunasan invoice #' . $invoice->number . ' melalui tautan konfirmasi',
+                        'description' => $invoice->itemDescriptionSummary(),
                         'date' => $now,
                     ]);
                 }


### PR DESCRIPTION
## Summary
- use the invoice item summary as the transaction description when debts or settlements create ledger entries
- default the settlement category to the invoice's first item when none is provided so categories stay consistent with invoice options

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e3726bd4a0832f893e2e2f8761c0a6