### PR TITLE
Allow admin and accountant roles to manage debts

### DIFF
--- a/app/Policies/DebtPolicy.php
+++ b/app/Policies/DebtPolicy.php
@@ -15,6 +15,10 @@ class DebtPolicy
 
     public function view(User $user, Debt $debt): bool
     {
+        if (in_array($user->role, [Role::ADMIN, Role::ACCOUNTANT], true)) {
+            return true;
+        }
+
         return $debt->user_id === $user->id;
     }
 
@@ -25,7 +29,7 @@ class DebtPolicy
 
     public function update(User $user, Debt $debt): bool
     {
-        if ($user->role === Role::ADMIN) {
+        if (in_array($user->role, [Role::ADMIN, Role::ACCOUNTANT], true)) {
             return true;
         }
 
@@ -34,6 +38,10 @@ class DebtPolicy
 
     public function delete(User $user, Debt $debt): bool
     {
+        if (in_array($user->role, [Role::ADMIN, Role::ACCOUNTANT], true)) {
+            return true;
+        }
+
         return $debt->user_id === $user->id;
     }
 }

--- a/tests/Feature/DebtPolicyTest.php
+++ b/tests/Feature/DebtPolicyTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\Role;
+use App\Models\Debt;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DebtPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_and_accountant_can_manage_other_users_debts(): void
+    {
+        $owner = User::factory()->create();
+        $debt = Debt::factory()->for($owner)->create();
+
+        $admin = User::factory()->create(['role' => Role::ADMIN]);
+        $accountant = User::factory()->create(['role' => Role::ACCOUNTANT]);
+
+        $this->assertTrue($admin->can('view', $debt));
+        $this->assertTrue($admin->can('update', $debt));
+        $this->assertTrue($admin->can('delete', $debt));
+
+        $this->assertTrue($accountant->can('view', $debt));
+        $this->assertTrue($accountant->can('update', $debt));
+        $this->assertTrue($accountant->can('delete', $debt));
+    }
+
+    public function test_non_privileged_users_cannot_manage_other_users_debts(): void
+    {
+        $owner = User::factory()->create();
+        $debt = Debt::factory()->for($owner)->create();
+
+        $otherStaff = User::factory()->create(['role' => Role::STAFF]);
+
+        $this->assertFalse($otherStaff->can('view', $debt));
+        $this->assertFalse($otherStaff->can('update', $debt));
+        $this->assertFalse($otherStaff->can('delete', $debt));
+    }
+}


### PR DESCRIPTION
## Summary
- allow admin and accountant roles to view, update, and delete any debt record
- add feature coverage confirming that only privileged roles can manage debts they do not own

## Testing
- php artisan test --filter DebtPolicyTest

------
https://chatgpt.com/codex/tasks/task_b_68e4826713cc83298512b7fdebfe615b