### PR TITLE
Allow admins and accountants to edit any transaction

### DIFF
--- a/app/Policies/TransactionPolicy.php
+++ b/app/Policies/TransactionPolicy.php
@@ -25,6 +25,10 @@ class TransactionPolicy
 
     public function update(User $user, Transaction $transaction): bool
     {
+        if (in_array($user->role, [Role::ADMIN, Role::ACCOUNTANT], true)) {
+            return true;
+        }
+
         return $transaction->user_id === $user->id;
     }
 


### PR DESCRIPTION
## Summary
- update the transaction policy so admins and accountants can edit any transaction
- keep staff limited to editing only the transactions they created

## Testing
- php artisan test *(fails: vendor/autoload.php missing in repository)*

------
https://chatgpt.com/codex/tasks/task_b_68e48d9788e48329963b1ce2e42e552b