### PR TITLE
Align transaction descriptions with invoice items

### DIFF
--- a/app/Http/Controllers/DebtController.php
+++ b/app/Http/Controllers/DebtController.php
@@ -147,7 +147,7 @@ class DebtController extends Controller
 
                     $invoice->save();
 
-                    $debt->description = $invoice->itemDescriptionSummary();
+                    $debt->description = $invoice->transactionDescription();
                     $debt->amount = $invoice->total;
                     $debt->due_date = $invoice->due_date;
                     $debt->related_party = $invoice->client_name

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -380,7 +380,7 @@ class InvoiceController extends Controller
             $debt = Debt::updateOrCreate(
                 ['invoice_id' => $invoice->id],
                 [
-                    'description' => $invoice->itemDescriptionSummary(),
+                    'description' => $invoice->transactionDescription(),
                     'related_party' => $relatedParty,
                     'type' => Debt::TYPE_DOWN_PAYMENT,
                     'amount' => $invoice->total,
@@ -427,7 +427,7 @@ class InvoiceController extends Controller
                 $debt->status = $invoice->status === 'lunas'
                     ? Debt::STATUS_LUNAS
                     : Debt::STATUS_BELUM_LUNAS;
-                $debt->description = $invoice->itemDescriptionSummary();
+                $debt->description = $invoice->transactionDescription();
                 $debt->amount = $invoice->total;
                 $debt->due_date = $invoice->due_date;
                 $debt->related_party = $relatedParty;
@@ -439,7 +439,7 @@ class InvoiceController extends Controller
                     'category_id' => $categoryId,
                     'user_id' => auth()->id(),
                     'amount' => $invoice->total,
-                    'description' => $invoice->itemDescriptionSummary(),
+                    'description' => $invoice->transactionDescription(),
                     'date' => $paymentDate,
                 ]);
             }
@@ -762,7 +762,7 @@ class InvoiceController extends Controller
         $relatedParty = $invoice->client_name
             ?: ($invoice->client_whatsapp ?: 'Klien Invoice #' . $invoice->number);
 
-        $debt->description = $invoice->itemDescriptionSummary();
+        $debt->description = $invoice->transactionDescription();
         $debt->amount = $invoice->total;
         $debt->due_date = $invoice->due_date;
         $debt->related_party = $relatedParty;

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -108,6 +108,19 @@ class Invoice extends Model
         return Str::limit($summary, $maxLength);
     }
 
+    public function transactionDescription(int $maxLength = 120): string
+    {
+        if ($this->type === self::TYPE_SETTLEMENT) {
+            $referenceInvoice = $this->referenceInvoice;
+
+            if ($referenceInvoice) {
+                return $referenceInvoice->itemDescriptionSummary($maxLength);
+            }
+        }
+
+        return $this->itemDescriptionSummary($maxLength);
+    }
+
     public function customerService(): BelongsTo
     {
         return $this->belongsTo(CustomerService::class);

--- a/app/Services/InvoiceSettlementService.php
+++ b/app/Services/InvoiceSettlementService.php
@@ -51,7 +51,7 @@ class InvoiceSettlementService
             $debt = Debt::updateOrCreate(
                 ['invoice_id' => $invoice->id],
                 [
-                    'description' => $invoice->itemDescriptionSummary(),
+                    'description' => $invoice->transactionDescription(),
                     'related_party' => $relatedParty,
                     'type' => Debt::TYPE_DOWN_PAYMENT,
                     'amount' => $invoiceTotal,
@@ -89,7 +89,7 @@ class InvoiceSettlementService
 
             $debt->forceFill([
                 'status' => Debt::STATUS_LUNAS,
-                'description' => $invoice->itemDescriptionSummary(),
+                'description' => $invoice->transactionDescription(),
                 'amount' => $invoiceTotal,
                 'due_date' => $invoice->due_date,
                 'related_party' => $relatedParty,
@@ -112,7 +112,7 @@ class InvoiceSettlementService
                         'category_id' => $categoryId,
                         'user_id' => $invoice->user_id,
                         'amount' => $remainingBalance,
-                        'description' => $invoice->itemDescriptionSummary(),
+                        'description' => $invoice->transactionDescription(),
                         'date' => $now,
                     ]);
                 }

--- a/tests/Feature/InvoiceSettlementTest.php
+++ b/tests/Feature/InvoiceSettlementTest.php
@@ -70,7 +70,7 @@ class InvoiceSettlementTest extends TestCase
         $this->assertSame(Debt::STATUS_LUNAS, $debt->status);
         $this->assertEquals($invoice->total, (float) $debt->payments()->sum('amount'));
 
-        $transaction = Transaction::where('description', 'Pelunasan invoice #' . $invoice->number . ' melalui tautan konfirmasi')->first();
+        $transaction = Transaction::where('description', $invoice->transactionDescription())->first();
         $this->assertNotNull($transaction);
         $this->assertEquals($invoice->user_id, $transaction->user_id);
         $this->assertEquals($invoice->total, (float) $transaction->amount);


### PR DESCRIPTION
## Summary
- add an Invoice::transactionDescription helper that falls back to the reference invoice when needed
- ensure debt syncing and transaction creation from invoices use the new helper so descriptions match invoice items
- update the invoice settlement feature test to assert the invoice-based description

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_b_68e48ecfb0388329aed38f5e072f433e