### PR TITLE
Ensure settlement invoices with active tokens appear in dashboard

### DIFF
--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -122,7 +122,13 @@ class InvoiceController extends Controller
 
         $settlementInvoices = $tabStates['settlement']['unlocked'] && $baseQuery
             ? (clone $baseQuery)
-                ->where('status', 'belum lunas')
+                ->whereIn('status', ['belum bayar', 'belum lunas'])
+                ->where('type', '!=', Invoice::TYPE_SETTLEMENT)
+                ->whereNotNull('settlement_token')
+                ->where(function ($query) {
+                    $query->whereNull('settlement_token_expires_at')
+                        ->orWhere('settlement_token_expires_at', '>', now());
+                })
                 ->get()
             : collect();
 


### PR DESCRIPTION
## Summary
- update the settlement tab query so only standard invoices with active settlement tokens are listed
- allow both "belum bayar" and "belum lunas" invoices to appear so the confirmation list is populated

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e4d0b831f88329869f2372abe2a721